### PR TITLE
Made linter more strict, minor refactorings and cleanup, fixed some tests

### DIFF
--- a/example-app/src/app/md-select-value-accessor.ts
+++ b/example-app/src/app/md-select-value-accessor.ts
@@ -32,14 +32,9 @@ export class NgrxMdSelectValueAccessor implements ControlValueAccessor {
       }
     }
 
-    if (!this.mdSelect.options) {
-      // initially the options will not have been created when the first value is set,
-      // therefore we defer setting the value to the end of the bindinig initialization
-      Promise.resolve().then(() => this.writeValue(value));
-      return;
-    }
-
-    this.mdSelect.writeValue(value);
+    // because the options are potentially updated AFTER the value (because of their order in the DOM),
+    // setting the value has to be deferred, otherwise we might select an option which is not available yet.
+    Promise.resolve().then(() => this.writeValue(value));
   }
 
   registerOnChange(fn: any) {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "build": "node build.js",
     "test": "karma start",
+    "lint": "tslint --type-check --project .",
     "pack-lib": "npm pack ./dist",
     "publish-lib": "npm publish ./dist",
     "compodoc": "compodoc -p tsconfig.json",

--- a/src/directive.ts
+++ b/src/directive.ts
@@ -1,7 +1,6 @@
 import {
   Directive,
   ElementRef,
-  Renderer2,
   Input,
   Inject,
   HostListener,
@@ -9,13 +8,11 @@ import {
   OnInit,
   OnDestroy,
   Self,
-  forwardRef,
 } from '@angular/core';
 import { DOCUMENT } from '@angular/platform-browser';
 import {
   NG_VALUE_ACCESSOR,
   ControlValueAccessor,
-  DefaultValueAccessor,
 } from '@angular/forms';
 import { ActionsSubject } from '@ngrx/store';
 import { Observable } from 'rxjs/Observable';

--- a/src/directive.ts
+++ b/src/directive.ts
@@ -85,7 +85,6 @@ export class NgrxFormControlDirective<TValue extends SupportedNgrxFormControlVal
       this.state$
         .map(s => s.value)
         .map(this.convertModelValue)
-        .distinctUntilChanged()
         .subscribe(value => this.valueAccessor.writeValue(value))
     );
 
@@ -93,7 +92,6 @@ export class NgrxFormControlDirective<TValue extends SupportedNgrxFormControlVal
       this.subscriptions.push(
         this.state$
           .map(s => s.isDisabled)
-          .distinctUntilChanged()
           .subscribe(isDisabled => this.valueAccessor.setDisabledState!(isDisabled))
       );
     }

--- a/src/reducer.spec.ts
+++ b/src/reducer.spec.ts
@@ -1,8 +1,13 @@
 import { ActionReducer } from '@ngrx/store';
 
-import { FormControlState, createFormControlState, FormGroupState, createFormGroupState } from './state';
 import {
-  Actions,
+  // tslint:disable-next-line:no-unused-variable FormControlState is used as a Generic
+  FormControlState,
+  createFormControlState,
+  FormGroupState,
+  createFormGroupState
+} from './state';
+import {
   SetValueAction,
   SetErrorsAction,
   MarkAsDirtyAction,
@@ -312,7 +317,7 @@ describe('ngrx-forms:', () => {
     });
 
     it('should not be stateful', () => {
-      const state = reducer(INITIAL_STATE_FULL, new SetValueAction(FORM_CONTROL_ID, INITIAL_FORM_CONTROL_VALUE));
+      reducer(INITIAL_STATE_FULL, new SetValueAction(FORM_CONTROL_ID, INITIAL_FORM_CONTROL_VALUE));
       expect(() => reducer(INITIAL_STATE_FULL, new MarkAsDirtyAction(FORM_CONTROL_ID))).not.toThrowError();
     });
 
@@ -1007,7 +1012,6 @@ describe('ngrx-forms:', () => {
       });
 
       it('should disable if all children are disabled when nested child is disabled', () => {
-        const inner3State = INITIAL_STATE_FULL.controls.inner3 as FormGroupState<any>;
         const state = {
           ...INITIAL_STATE_FULL,
           controls: {

--- a/src/reducer.spec.ts
+++ b/src/reducer.spec.ts
@@ -276,10 +276,9 @@ describe('ngrx-forms:', () => {
 
   describe('form group reducer', () => {
     const FORM_CONTROL_ID = 'test ID';
-    const FORM_CONTROL_INNER_ID = 'test ID.inner';
-    const FORM_CONTROL_INNER2_ID = 'test ID.inner2';
-    const FORM_CONTROL_INNER3_ID = 'test ID.inner3';
-    const FORM_CONTROL_INNER4_ID = 'test ID.inner3.inner4';
+    const FORM_CONTROL_INNER_ID = FORM_CONTROL_ID + '.inner';
+    const FORM_CONTROL_INNER3_ID = FORM_CONTROL_ID + '.inner3';
+    const FORM_CONTROL_INNER4_ID = FORM_CONTROL_ID + '.inner3.inner4';
     interface FormGroupValue { inner: string; inner2?: string; inner3?: { inner4: string }; }
     const INITIAL_FORM_CONTROL_VALUE: FormGroupValue = { inner: '' };
     const INITIAL_FORM_CONTROL_VALUE_FULL: FormGroupValue = { inner: '', inner2: '', inner3: { inner4: '' } };
@@ -733,7 +732,7 @@ describe('ngrx-forms:', () => {
             },
           },
         };
-        const resultState = reducer(INITIAL_STATE_FULL, new MarkAsPristineAction(FORM_CONTROL_INNER3_ID));
+        const resultState = reducer(state, new MarkAsPristineAction(FORM_CONTROL_INNER3_ID));
         expect(resultState.isDirty).toEqual(false);
         expect(resultState.isPristine).toEqual(true);
       });
@@ -1183,7 +1182,7 @@ describe('ngrx-forms:', () => {
             },
           },
         };
-        const resultState = reducer(INITIAL_STATE, new MarkAsUntouchedAction(FORM_CONTROL_INNER_ID));
+        const resultState = reducer(state, new MarkAsUntouchedAction(FORM_CONTROL_INNER_ID));
         expect(resultState.isTouched).toEqual(false);
         expect(resultState.isUntouched).toEqual(true);
       });
@@ -1412,7 +1411,7 @@ describe('ngrx-forms:', () => {
             },
           },
         };
-        const resultState = reducer(INITIAL_STATE, new MarkAsUnsubmittedAction(FORM_CONTROL_INNER_ID));
+        const resultState = reducer(state, new MarkAsUnsubmittedAction(FORM_CONTROL_INNER_ID));
         expect(resultState.isSubmitted).toEqual(false);
         expect(resultState.isUnsubmitted).toEqual(true);
       });

--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -32,9 +32,9 @@ function isEmpty(obj: object) {
 
 export function formControlReducer<TValue extends SupportedNgrxFormControlValueTypes>(
   state: FormControlState<TValue>,
-  action: Action,
+  action: Actions<TValue>,
 ) {
-  return formControlReducerInternal(state, action as any);
+  return formControlReducerInternal(state, action);
 }
 
 export function formControlReducerInternal<TValue extends SupportedNgrxFormControlValueTypes>(
@@ -266,11 +266,15 @@ function callChildReducer(
   state: AbstractControlState<any>,
   action: Actions<any>,
 ): AbstractControlState<any> {
-  if (state.hasOwnProperty('controls')) {
+  if (isGroupState(state)) {
     return formGroupReducerInternal(state as FormGroupState<any>, action);
   }
 
   return formControlReducerInternal(state as FormControlState<any>, action);
+}
+
+function isGroupState(state: AbstractControlState<any>): boolean {
+  return state.hasOwnProperty('controls');
 }
 
 function callChildReducers<TValue extends { [key: string]: any }>(controls: Controls<TValue>, action: Actions<TValue>): Controls<TValue> {

--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -32,9 +32,9 @@ function isEmpty(obj: object) {
 
 export function formControlReducer<TValue extends SupportedNgrxFormControlValueTypes>(
   state: FormControlState<TValue>,
-  action: Actions<TValue>,
+  action: Action,
 ) {
-  return formControlReducerInternal(state, action);
+  return formControlReducerInternal(state, action as any);
 }
 
 export function formControlReducerInternal<TValue extends SupportedNgrxFormControlValueTypes>(

--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -1,4 +1,4 @@
-import { ActionReducer, Action } from '@ngrx/store';
+import { Action } from '@ngrx/store';
 import { ValidationErrors } from '@angular/forms';
 
 import {

--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -262,6 +262,10 @@ function createChildState(id: string, childValue: any): AbstractControlState<any
   return createFormControlState(id, childValue);
 }
 
+function isGroupState(state: AbstractControlState<any>): boolean {
+  return state.hasOwnProperty('controls');
+}
+
 function callChildReducer(
   state: AbstractControlState<any>,
   action: Actions<any>,
@@ -271,10 +275,6 @@ function callChildReducer(
   }
 
   return formControlReducerInternal(state as FormControlState<any>, action);
-}
-
-function isGroupState(state: AbstractControlState<any>): boolean {
-  return state.hasOwnProperty('controls');
 }
 
 function callChildReducers<TValue extends { [key: string]: any }>(controls: Controls<TValue>, action: Actions<TValue>): Controls<TValue> {

--- a/tslint.json
+++ b/tslint.json
@@ -74,6 +74,8 @@
     "max-line-length": [
       true,
       140
-    ]
+    ],
+    "no-unused-expression": true,
+    "no-unused-variable": true
   }
 }


### PR DESCRIPTION
Additionally: The test _form group reducer_: _should not be stateful_ could be named/documented better. I can kinda imagine what the issue is, but still.