### PR TITLE
Migrate example-app to @angular/material 5.0.0-rc0 and give a better errorState hack

### DIFF
--- a/example-app/package-lock.json
+++ b/example-app/package-lock.json
@@ -24,9 +24,9 @@
       }
     },
     "@angular/cdk": {
-      "version": "2.0.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-2.0.0-beta.8.tgz",
-      "integrity": "sha512-OOtK+AA14cmRG9AbUgvoKC9Tooz0N37GTaRSV+xziC8GxXHgwvTu4PFSFHlBnHPipOYC/tB2oP39j3KuurEMPA==",
+      "version": "5.0.0-rc0",
+      "resolved": "http://nexus.aic.serpro/repository/npm-group/@angular/cdk/-/cdk-5.0.0-rc0.tgz",
+      "integrity": "sha512-wZg/mzHisiTieVt7Q/YNPB+r07PHvjoAT3+0mwyIP7wuC00W8BJLPhTZd/tIM5q7Nd69kuA1HSx1qLkcmlCZkw==",
       "requires": {
         "tslib": "1.7.1"
       }
@@ -81,7 +81,7 @@
         "raw-loader": "0.5.1",
         "resolve": "1.4.0",
         "rsvp": "3.6.2",
-        "rxjs": "5.4.3",
+        "rxjs": "5.5.2",
         "sass-loader": "6.0.6",
         "script-loader": "0.7.0",
         "semver": "5.4.1",
@@ -647,9 +647,9 @@
       "dev": true
     },
     "@angular/material": {
-      "version": "2.0.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@angular/material/-/material-2.0.0-beta.8.tgz",
-      "integrity": "sha512-4+OecvjU15i+l/vXBP2qEHdlsU9taK6kBhsWKsxNLK3+TAVoV5qjc2rjOucHtTwI/oOjyBXnLJP6pl4tuLEUQw==",
+      "version": "5.0.0-rc0",
+      "resolved": "http://nexus.aic.serpro/repository/npm-group/@angular/material/-/material-5.0.0-rc0.tgz",
+      "integrity": "sha512-ZW9gy3c8l2NbFfX9DRYSW+i67pPoL9DZoMCb16STQlhdDfwwAWNpjGF0etXkXw30hDnRCMGVVJVU+45cNXJspA==",
       "requires": {
         "tslib": "1.7.1"
       }
@@ -7130,9 +7130,9 @@
       }
     },
     "rxjs": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.4.3.tgz",
-      "integrity": "sha512-fSNi+y+P9ss+EZuV0GcIIqPUK07DEaMRUtLJvdcvMyFjc9dizuDjere+A4V7JrLGnm9iCc+nagV/4QdMTkqC4A==",
+      "version": "5.5.2",
+      "resolved": "http://nexus.aic.serpro/repository/npm-group/rxjs/-/rxjs-5.5.2.tgz",
+      "integrity": "sha512-oRYoIKWBU3Ic37fLA5VJu31VqQO4bWubRntcHSJ+cwaDQBwdnZ9x4zmhJfm/nFQ2E82/I4loSioHnACamrKGgA==",
       "requires": {
         "symbol-observable": "1.0.4"
       }

--- a/example-app/package.json
+++ b/example-app/package.json
@@ -13,13 +13,13 @@
   "private": true,
   "dependencies": {
     "@angular/animations": "^4.0.0",
-    "@angular/cdk": "^2.0.0-beta.8",
+    "@angular/cdk": "^5.0.0-rc0",
     "@angular/common": "^4.0.0",
     "@angular/compiler": "^4.0.0",
     "@angular/core": "^4.0.0",
     "@angular/forms": "^4.0.0",
     "@angular/http": "^4.0.0",
-    "@angular/material": "^2.0.0-beta.8",
+    "@angular/material": "^5.0.0-rc0",
     "@angular/platform-browser": "^4.0.0",
     "@angular/platform-browser-dynamic": "^4.0.0",
     "@angular/router": "^4.0.0",
@@ -28,7 +28,7 @@
     "@ngrx/store-devtools": "^4.0.0",
     "core-js": "^2.4.1",
     "ngrx-forms": "^1.1.1",
-    "rxjs": "^5.1.0",
+    "rxjs": "^5.5.2",
     "zone.js": "^0.8.4"
   },
   "devDependencies": {

--- a/example-app/src/app/app.component.html
+++ b/example-app/src/app/app.component.html
@@ -1,9 +1,9 @@
 <div class="main-content">
-  <md-card class="todo-list">
-    <md-card-header>
-      <md-card-title>Todos</md-card-title>
-    </md-card-header>
-    <md-card-content>
+  <mat-card class="todo-list">
+    <mat-card-header>
+      <mat-card-title>Todos</mat-card-title>
+    </mat-card-header>
+    <mat-card-content>
       <div class="description">
         Notes: <br/>
         - the "Priority" input is only enabled for the "Work" category<br/>
@@ -11,19 +11,19 @@
       </div>
       <app-item-form [formState]="formState$ | async"
                      (addTodoItem)="addTodoItem($event)"></app-item-form>
-      <md-list>
-        <md-list-item *ngFor="let item of items$ | async">
+      <mat-list>
+        <mat-list-item *ngFor="let item of items$ | async">
           <div class="list-item">
             <div class="category">{{item.category}}</div>
             <div class="text">{{item.text}}</div>
             <div class="priority">{{item.meta.priority > 0 ? item.meta.priority : ''}}</div>
             <div class="duedate">{{formatDate(item.meta.duedate)}}</div>
           </div>
-        </md-list-item>
-      </md-list>
-    </md-card-content>
-  </md-card>
-  <md-card class="state">
+        </mat-list-item>
+      </mat-list>
+    </mat-card-content>
+  </mat-card>
+  <mat-card class="state">
     <pre>{{formState$ | async | json}}</pre>
-  </md-card>
+  </mat-card>
 </div>

--- a/example-app/src/app/app.module.ts
+++ b/example-app/src/app/app.module.ts
@@ -5,25 +5,35 @@ import { StoreModule } from '@ngrx/store';
 import { StoreDevtoolsModule } from '@ngrx/store-devtools';
 import { EffectsModule } from '@ngrx/effects';
 import { HttpModule } from '@angular/http';
-import { MaterialModule, MdNativeDateModule } from '@angular/material';
+import { MatNativeDateModule,
+   MatSelectModule,
+   MatInputModule,
+   MatCardModule,
+   MatListModule,
+   MatDatepickerModule } from '@angular/material';
 import { NgrxFormsModule } from 'ngrx-forms';
 
 import { reducers } from './app.reducer';
 import { AppComponent } from './app.component';
 import { ItemFormComponent } from './item-form/item-form.component';
-import { NgrxMdSelectValueAccessor } from './md-select-value-accessor';
-
+import { NgrxMatSelectValueAccessor } from './mat-select-value-accessor';
+import { NgrxValidateMatFormFieldControl } from './mat-validate-form-field-control';
 @NgModule({
   declarations: [
     AppComponent,
     ItemFormComponent,
-    NgrxMdSelectValueAccessor,
+    NgrxMatSelectValueAccessor,
+    NgrxValidateMatFormFieldControl
   ],
   imports: [
     BrowserModule,
     BrowserAnimationsModule,
-    MaterialModule,
-    MdNativeDateModule,
+    MatSelectModule,
+    MatInputModule,
+    MatCardModule,
+    MatListModule,
+    MatDatepickerModule,
+    MatNativeDateModule,
     NgrxFormsModule,
     HttpModule,
     StoreModule.forRoot(reducers),

--- a/example-app/src/app/item-form/item-form.component.html
+++ b/example-app/src/app/item-form/item-form.component.html
@@ -2,52 +2,51 @@
       [ngrxFormState]="formState"
       (submit)="onSubmit()">
   <div class="first-row">
-    <md-select placeholder="Category"
+    <mat-select placeholder="Category"
                [ngrxFormControlState]="formState.controls.category"
                [ngrxEnableFocusTracking]="true">
-      <md-option value="Private">Private</md-option>
-      <md-option value="Work">Work</md-option>
-    </md-select>
-    <md-input-container floatPlaceholder="always">
+      <mat-option value="Private">Private</mat-option>
+      <mat-option value="Work">Work</mat-option>
+    </mat-select>
+    <mat-input-container floatPlaceholder="always">
       <input type="number"
-             mdInput
+             matInput
              id="priority"
              [placeholder]="metaState.controls.priority.isEnabled ? 'Priority' : 'Priority (disabled)'"
              [ngrxFormControlState]="metaState.controls.priority"
              [ngrxEnableFocusTracking]="true"
              [ngrxEnableLastKeydownCodeTracking]="true">
 
-      <md-error *ngIf="metaState.controls.priority.errors.required">
+      <mat-error *ngIf="metaState.controls.priority.errors.required">
         A priority is required
-      </md-error>
+      </mat-error>
 
-      <md-error *ngIf="metaState.controls.priority.errors.min">
+      <mat-error *ngIf="metaState.controls.priority.errors.min">
         Priority must be at least 1
-      </md-error>
-    </md-input-container>
-    <md-input-container>
-      <input mdInput
+      </mat-error>
+    </mat-input-container>
+    <mat-input-container>
+      <input matInput
              id="duedate"
-             [mdDatepicker]="picker"
+             [matDatepicker]="picker"
              placeholder="Due date"
              [ngrxFormControlState]="metaState.controls.duedate"
              [ngrxValueConverter]="dateValueConverter"
              [ngrxEnableFocusTracking]="true"
              [ngrxEnableLastKeydownCodeTracking]="true">
+      <mat-datepicker #picker></mat-datepicker>
+      <button matSuffix (click)="picker.open()"></button>
 
-      <button mdSuffix
-              [mdDatepickerToggle]="picker"></button>
-
-      <md-error *ngIf="metaState.controls.duedate.errors.required">
+      <mat-error *ngIf="metaState.controls.duedate.errors.required">
         A due date is required
-      </md-error>
-    </md-input-container>
-    <md-datepicker #picker></md-datepicker>
+      </mat-error>
+    </mat-input-container>
+    <mat-datepicker #picker></mat-datepicker>
   </div>
   <div class="second-row">
-    <md-input-container>
+    <mat-input-container>
       <input type="text"
-             mdInput
+             matInput
              id="text"
              placeholder="Text"
              #textInput
@@ -56,11 +55,11 @@
              [ngrxEnableFocusTracking]="true"
              [ngrxEnableLastKeydownCodeTracking]="true">
 
-      <md-hint align="end">
+      <mat-hint align="end">
         {{textInput.value?.length || 0}} / 50
-      </md-hint>
+      </mat-hint>
 
-      <md-error *ngIf="formState.controls.text.errors.required">
+      <mat-error *ngIf="formState.controls.text.errors.required">
         <span>
           A text is required
         </span>
@@ -68,9 +67,9 @@
         <span>
           {{textInput.value?.length || 0}} / 50
         </span>
-      </md-error>
+      </mat-error>
 
-      <md-error *ngIf="formState.controls.text.errors.maxLength">        
+      <mat-error *ngIf="formState.controls.text.errors.maxLength">        
         <span>
           The text may be at most 50 characters long
         </span>
@@ -78,9 +77,9 @@
         <span>
           {{textInput.value?.length || 0}} / 50
         </span>
-      </md-error>
-    </md-input-container>
-    <button md-raised-button
+      </mat-error>
+    </mat-input-container>
+    <button mat-raised-button
             color="primary"
             type="submit"
             [disabled]="formState.isInvalid && formState.isSubmitted">

--- a/example-app/src/app/item-form/item-form.component.ts
+++ b/example-app/src/app/item-form/item-form.component.ts
@@ -1,5 +1,4 @@
 import { Component, Input, Output, EventEmitter, ViewChildren, AfterViewInit, QueryList, ChangeDetectionStrategy } from '@angular/core';
-import { MdInputDirective } from '@angular/material';
 import { FormGroupState, AbstractControlState, NgrxValueConverter, NgrxValueConverters } from 'ngrx-forms';
 
 import { ItemFormValue } from './item-form.state';
@@ -11,11 +10,9 @@ import { TodoItem } from '../app.state';
   styleUrls: ['./item-form.component.css'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class ItemFormComponent implements AfterViewInit {
+export class ItemFormComponent {
   @Input() formState: FormGroupState<ItemFormValue>;
   @Output() addTodoItem = new EventEmitter<TodoItem>();
-
-  @ViewChildren(MdInputDirective) inputs: QueryList<MdInputDirective>;
 
   get metaState(): FormGroupState<any> {
     return this.formState.controls.meta as FormGroupState<any>;
@@ -33,17 +30,6 @@ export class ItemFormComponent implements AfterViewInit {
     },
     convertStateToViewValue: NgrxValueConverters.dateToISOString.convertStateToViewValue,
   };
-
-  ngAfterViewInit() {
-    const isErrorState = (state: AbstractControlState<any>) => state.isInvalid && (state.isDirty || state.isTouched || state.isSubmitted);
-
-    // sadly, material 2 only properly integrates its error handling with @angular/forms; therefore
-    // we have to implement a small hack to make error messages work
-    const meta = () => this.formState.controls.meta as FormGroupState<any>;
-    this.inputs.find(i => i.id === 'priority')!._isErrorState = () => isErrorState(meta().controls.priority);
-    this.inputs.find(i => i.id === 'duedate')!._isErrorState = () => isErrorState(meta().controls.duedate);
-    this.inputs.find(i => i.id === 'text')!._isErrorState = () => isErrorState(this.formState.controls.text);
-  }
 
   onSubmit() {
     if (this.formState.isInvalid) {

--- a/example-app/src/app/mat-select-value-accessor.ts
+++ b/example-app/src/app/mat-select-value-accessor.ts
@@ -1,29 +1,29 @@
 import { Directive, forwardRef } from '@angular/core';
 import { NG_VALUE_ACCESSOR, ControlValueAccessor, } from '@angular/forms';
 
-import { MdSelect, MdOption } from '@angular/material';
+import { MatSelect, MatOption } from '@angular/material';
 
 // tslint:disable:directive-selector
 // tslint:disable:directive-class-suffix
-// necessary since material 2 does not properly declare the md-select as a NG_VALUE_ACCESSOR
+// necessary since material 2 does not properly declare the mat-select as a NG_VALUE_ACCESSOR
 @Directive({
-  selector: 'md-select[ngrxFormControlState]',
+  selector: 'mat-select[ngrxFormControlState]',
   providers: [{
     provide: NG_VALUE_ACCESSOR,
-    useExisting: forwardRef(() => NgrxMdSelectValueAccessor),
+    useExisting: forwardRef(() => NgrxMatSelectValueAccessor),
     multi: true
   }]
 })
-export class NgrxMdSelectValueAccessor implements ControlValueAccessor {
-  constructor(private mdSelect: MdSelect) { }
+export class NgrxMatSelectValueAccessor implements ControlValueAccessor {
+  constructor(private matSelect: MatSelect) { }
 
   writeValue(value: any) {
     // we have to verify that the same value is not set again since that would
     // cause focs to get lost on the select since it tries to focus the active option
-    const selectedOption = this.mdSelect.selected;
+    const selectedOption = this.matSelect.selected;
     if (selectedOption) {
       if (Object.prototype.toString.call(selectedOption) !== '[object Array]') {
-        const selectedValue = (<MdOption>selectedOption).value;
+        const selectedValue = (<MatOption>selectedOption).value;
         if (value === selectedValue) {
           return;
         }
@@ -34,14 +34,14 @@ export class NgrxMdSelectValueAccessor implements ControlValueAccessor {
 
     // because the options are potentially updated AFTER the value (because of their order in the DOM),
     // setting the value has to be deferred, otherwise we might select an option which is not available yet.
-    Promise.resolve().then(() => this.mdSelect.writeValue(value));
+    Promise.resolve().then(() => this.matSelect.writeValue(value));
   }
 
   registerOnChange(fn: any) {
-    this.mdSelect.registerOnChange(fn);
+    this.matSelect.registerOnChange(fn);
   }
 
   registerOnTouched(fn: any) {
-    this.mdSelect.registerOnTouched(fn);
+    this.matSelect.registerOnTouched(fn);
   }
 }

--- a/example-app/src/app/mat-validate-form-field-control.ts
+++ b/example-app/src/app/mat-validate-form-field-control.ts
@@ -15,8 +15,7 @@ export class NgrxValidateMatFormFieldControl implements OnChanges {
   constructor(private input: MatFormFieldControl<any>) {
   }
 
-  ngOnChanges(changes: SimpleChanges): void {
-    console.log(changes);
+  ngOnChanges(changes: SimpleChanges): void {    
     const isErrorState = () => this.ngrxFormControlState.isInvalid &&
       (this.ngrxFormControlState.isDirty
         || this.ngrxFormControlState.isTouched

--- a/example-app/src/app/mat-validate-form-field-control.ts
+++ b/example-app/src/app/mat-validate-form-field-control.ts
@@ -1,0 +1,28 @@
+import {AfterViewInit, Directive, Input, OnChanges, SimpleChanges} from '@angular/core';
+import {FormControlState} from 'ngrx-forms';
+import {MatFormFieldControl} from '@angular/material/form-field';
+
+
+// Sadly, material 2 only properly integrates its error handling with @angular/forms;
+// therefore, we have to add the errorState field to all field controls.
+@Directive({
+  selector: '[ngrxFormControlState]',
+})
+export class NgrxValidateMatFormFieldControl implements OnChanges {
+
+  @Input() ngrxFormControlState: FormControlState<any>;
+
+  constructor(private input: MatFormFieldControl<any>) {
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    console.log(changes);
+    const isErrorState = () => this.ngrxFormControlState.isInvalid &&
+      (this.ngrxFormControlState.isDirty
+        || this.ngrxFormControlState.isTouched
+        || this.ngrxFormControlState.isSubmitted);
+    (this.input as any).errorState = isErrorState();
+  }
+
+}
+


### PR DESCRIPTION
I migrated the example-app to Angular Material 5. A nice side effect is the possibility of a better workaround for the lack of errorState handling for the fields via the NgrxValidateMatFormFieldControl directive.