### PR TITLE
Reducers can occasionally receive actions without a type

### DIFF
--- a/src/actions.spec.ts
+++ b/src/actions.spec.ts
@@ -4,12 +4,15 @@ describe('action', () => {
   it('should return true if type is ngrx/forms/', () => {
     expect(isNgrxFormsAction({ type: 'ngrx/forms/' })).toBeTruthy();
   });
+
   it('should return true if type startsWith ngrx/forms/', () => {
     expect(isNgrxFormsAction({ type: 'ngrx/forms/test' })).toBeTruthy();
   });
+
   it('should return false if type does not have ngrx/forms/', () => {
     expect(isNgrxFormsAction({ type: 'some-type' })).toBeFalsy();
   });
+
   it('should return false if type is missing', () => {
     expect(isNgrxFormsAction({} as any)).toBeFalsy();
   });

--- a/src/actions.spec.ts
+++ b/src/actions.spec.ts
@@ -2,18 +2,18 @@ import { isNgrxFormsAction } from './actions';
 
 describe('action', () => {
   it('should return true if type is ngrx/forms/', () => {
-    expect(isNgrxFormsAction({ type: 'ngrx/forms/' })).toBeTruthy();
+    expect(isNgrxFormsAction({ type: 'ngrx/forms/' })).toBe(true);
   });
 
   it('should return true if type startsWith ngrx/forms/', () => {
-    expect(isNgrxFormsAction({ type: 'ngrx/forms/test' })).toBeTruthy();
+    expect(isNgrxFormsAction({ type: 'ngrx/forms/test' })).toBe(true);
   });
 
   it('should return false if type does not have ngrx/forms/', () => {
-    expect(isNgrxFormsAction({ type: 'some-type' })).toBeFalsy();
+    expect(isNgrxFormsAction({ type: 'some-type' })).toBe(false);
   });
 
   it('should return false if type is missing', () => {
-    expect(isNgrxFormsAction({} as any)).toBeFalsy();
+    expect(isNgrxFormsAction({} as any)).toBe(false);
   });
 });

--- a/src/actions.spec.ts
+++ b/src/actions.spec.ts
@@ -1,6 +1,6 @@
 import { isNgrxFormsAction } from './actions';
 
-describe('action', () => {
+describe(isNgrxFormsAction.name, () => {
   it('should return true if type is ngrx/forms/', () => {
     expect(isNgrxFormsAction({ type: 'ngrx/forms/' })).toBe(true);
   });

--- a/src/actions.spec.ts
+++ b/src/actions.spec.ts
@@ -1,0 +1,16 @@
+import { isNgrxFormsAction } from './actions';
+
+describe('action', () => {
+  it('should return true if type is ngrx/forms/', () => {
+    expect(isNgrxFormsAction({ type: 'ngrx/forms/' })).toBeTruthy();
+  });
+  it('should return true if type startsWith ngrx/forms/', () => {
+    expect(isNgrxFormsAction({ type: 'ngrx/forms/test' })).toBeTruthy();
+  });
+  it('should return false if type does not have ngrx/forms/', () => {
+    expect(isNgrxFormsAction({ type: 'some-type' })).toBeFalsy();
+  });
+  it('should return false if type is missing', () => {
+    expect(isNgrxFormsAction({} as any)).toBeFalsy();
+  });
+});

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -334,5 +334,5 @@ export type Actions<TValue> =
   ;
 
 export function isNgrxFormsAction(action: Action) {
-  return action.type.startsWith('ngrx/forms/');
+  return action.type && action.type.startsWith('ngrx/forms/');
 }

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -2,8 +2,10 @@ import { Action } from '@ngrx/store';
 import { ValidationErrors } from '@angular/forms';
 import { NgrxFormControlId, KeyValue } from './state';
 
+export const ngrxFormsActionPrefix = 'ngrx/forms';
+
 export class SetValueAction<TValue> implements Action {
-  static readonly TYPE = 'ngrx/forms/SET_VALUE';
+  static readonly TYPE = `${ngrxFormsActionPrefix}/SET_VALUE`;
   readonly type = SetValueAction.TYPE;
   readonly controlId: NgrxFormControlId;
 
@@ -21,7 +23,7 @@ export class SetValueAction<TValue> implements Action {
 }
 
 export class SetErrorsAction implements Action {
-  static readonly TYPE = 'ngrx/forms/SET_ERRORS';
+  static readonly TYPE = `${ngrxFormsActionPrefix}/SET_ERRORS`;
   readonly type = SetErrorsAction.TYPE;
   readonly controlId: NgrxFormControlId;
 
@@ -41,7 +43,7 @@ export class SetErrorsAction implements Action {
 }
 
 export class SetAsyncErrorAction implements Action {
-  static readonly TYPE = 'ngrx/forms/SET_ASYNC_ERROR';
+  static readonly TYPE = `${ngrxFormsActionPrefix}/SET_ASYNC_ERROR`;
   readonly type = SetAsyncErrorAction.TYPE;
   readonly controlId: NgrxFormControlId;
 
@@ -64,7 +66,7 @@ export class SetAsyncErrorAction implements Action {
 }
 
 export class ClearAsyncErrorAction implements Action {
-  static readonly TYPE = 'ngrx/forms/CLEAR_ASYNC_ERROR';
+  static readonly TYPE = `${ngrxFormsActionPrefix}/CLEAR_ASYNC_ERROR`;
   readonly type = ClearAsyncErrorAction.TYPE;
   readonly controlId: NgrxFormControlId;
 
@@ -84,7 +86,7 @@ export class ClearAsyncErrorAction implements Action {
 }
 
 export class StartAsyncValidationAction implements Action {
-  static readonly TYPE = 'ngrx/forms/START_ASYNC_VALIDATION';
+  static readonly TYPE = `${ngrxFormsActionPrefix}/START_ASYNC_VALIDATION`;
   readonly type = StartAsyncValidationAction.TYPE;
   readonly controlId: NgrxFormControlId;
 
@@ -104,7 +106,7 @@ export class StartAsyncValidationAction implements Action {
 }
 
 export class MarkAsDirtyAction implements Action {
-  static readonly TYPE = 'ngrx/forms/MARK_AS_DIRTY';
+  static readonly TYPE = `${ngrxFormsActionPrefix}/MARK_AS_DIRTY`;
   readonly type = MarkAsDirtyAction.TYPE;
   readonly controlId: NgrxFormControlId;
 
@@ -114,7 +116,7 @@ export class MarkAsDirtyAction implements Action {
 }
 
 export class MarkAsPristineAction implements Action {
-  static readonly TYPE = 'ngrx/forms/MARK_AS_PRISTINE';
+  static readonly TYPE = `${ngrxFormsActionPrefix}/MARK_AS_PRISTINE`;
   readonly type = MarkAsPristineAction.TYPE;
   readonly controlId: NgrxFormControlId;
 
@@ -124,7 +126,7 @@ export class MarkAsPristineAction implements Action {
 }
 
 export class EnableAction implements Action {
-  static readonly TYPE = 'ngrx/forms/ENABLE';
+  static readonly TYPE = `${ngrxFormsActionPrefix}/ENABLE`;
   readonly type = EnableAction.TYPE;
   readonly controlId: NgrxFormControlId;
 
@@ -134,7 +136,7 @@ export class EnableAction implements Action {
 }
 
 export class DisableAction implements Action {
-  static readonly TYPE = 'ngrx/forms/DISABLE';
+  static readonly TYPE = `${ngrxFormsActionPrefix}/DISABLE`;
   readonly type = DisableAction.TYPE;
   readonly controlId: NgrxFormControlId;
 
@@ -144,7 +146,7 @@ export class DisableAction implements Action {
 }
 
 export class MarkAsTouchedAction implements Action {
-  static readonly TYPE = 'ngrx/forms/MARK_AS_TOUCHED';
+  static readonly TYPE = `${ngrxFormsActionPrefix}/MARK_AS_TOUCHED`;
   readonly type = MarkAsTouchedAction.TYPE;
   readonly controlId: NgrxFormControlId;
 
@@ -154,7 +156,7 @@ export class MarkAsTouchedAction implements Action {
 }
 
 export class MarkAsUntouchedAction implements Action {
-  static readonly TYPE = 'ngrx/forms/MARK_AS_UNTOUCHED';
+  static readonly TYPE = `${ngrxFormsActionPrefix}/MARK_AS_UNTOUCHED`;
   readonly type = MarkAsUntouchedAction.TYPE;
   readonly controlId: NgrxFormControlId;
 
@@ -164,7 +166,7 @@ export class MarkAsUntouchedAction implements Action {
 }
 
 export class FocusAction implements Action {
-  static readonly TYPE = 'ngrx/forms/FOCUS';
+  static readonly TYPE = `${ngrxFormsActionPrefix}/FOCUS`;
   readonly type = FocusAction.TYPE;
   readonly controlId: NgrxFormControlId;
 
@@ -174,7 +176,7 @@ export class FocusAction implements Action {
 }
 
 export class UnfocusAction implements Action {
-  static readonly TYPE = 'ngrx/forms/UNFOCUS';
+  static readonly TYPE = `${ngrxFormsActionPrefix}/UNFOCUS`;
   readonly type = UnfocusAction.TYPE;
   readonly controlId: NgrxFormControlId;
 
@@ -184,7 +186,7 @@ export class UnfocusAction implements Action {
 }
 
 export class MarkAsSubmittedAction implements Action {
-  static readonly TYPE = 'ngrx/forms/MARK_AS_SUBMITTED';
+  static readonly TYPE = `${ngrxFormsActionPrefix}/MARK_AS_SUBMITTED`;
   readonly type = MarkAsSubmittedAction.TYPE;
   readonly controlId: NgrxFormControlId;
 
@@ -194,7 +196,7 @@ export class MarkAsSubmittedAction implements Action {
 }
 
 export class MarkAsUnsubmittedAction implements Action {
-  static readonly TYPE = 'ngrx/forms/MARK_AS_UNSUBMITTED';
+  static readonly TYPE = `${ngrxFormsActionPrefix}/MARK_AS_UNSUBMITTED`;
   readonly type = MarkAsUnsubmittedAction.TYPE;
   readonly controlId: NgrxFormControlId;
 
@@ -204,7 +206,7 @@ export class MarkAsUnsubmittedAction implements Action {
 }
 
 export class AddArrayControlAction<TValue> implements Action {
-  static readonly TYPE = 'ngrx/forms/ADD_ARRAY_CONTROL';
+  static readonly TYPE = `${ngrxFormsActionPrefix}/ADD_ARRAY_CONTROL`;
   readonly type = AddArrayControlAction.TYPE;
   readonly controlId: NgrxFormControlId;
 
@@ -224,7 +226,7 @@ export class AddArrayControlAction<TValue> implements Action {
 }
 
 export class AddGroupControlAction<TValue extends KeyValue, TControlKey extends keyof TValue = string> implements Action {
-  static readonly TYPE = 'ngrx/forms/ADD_GROUP_CONTROL';
+  static readonly TYPE = `${ngrxFormsActionPrefix}/ADD_GROUP_CONTROL`;
   readonly type = AddGroupControlAction.TYPE;
   readonly controlId: NgrxFormControlId;
 
@@ -244,7 +246,7 @@ export class AddGroupControlAction<TValue extends KeyValue, TControlKey extends 
 }
 
 export class RemoveArrayControlAction implements Action {
-  static readonly TYPE = 'ngrx/forms/REMOVE_ARRAY_CONTROL';
+  static readonly TYPE = `${ngrxFormsActionPrefix}/REMOVE_ARRAY_CONTROL`;
   readonly type = RemoveArrayControlAction.TYPE;
   readonly controlId: NgrxFormControlId;
 
@@ -262,7 +264,7 @@ export class RemoveArrayControlAction implements Action {
 }
 
 export class RemoveGroupControlAction<TValue> implements Action {
-  static readonly TYPE = 'ngrx/forms/REMOVE_CONTROL';
+  static readonly TYPE = `${ngrxFormsActionPrefix}/REMOVE_CONTROL`;
   readonly type = RemoveGroupControlAction.TYPE;
   readonly controlId: NgrxFormControlId;
 
@@ -280,7 +282,7 @@ export class RemoveGroupControlAction<TValue> implements Action {
 }
 
 export class SetUserDefinedPropertyAction implements Action {
-  static readonly TYPE = 'ngrx/forms/SET_USER_DEFINED_PROPERTY';
+  static readonly TYPE = `${ngrxFormsActionPrefix}/SET_USER_DEFINED_PROPERTY`;
   readonly type = SetUserDefinedPropertyAction.TYPE;
   readonly controlId: NgrxFormControlId;
 
@@ -300,7 +302,7 @@ export class SetUserDefinedPropertyAction implements Action {
 }
 
 export class ResetAction implements Action {
-  static readonly TYPE = 'ngrx/forms/RESET';
+  static readonly TYPE = `${ngrxFormsActionPrefix}/RESET`;
   readonly type = ResetAction.TYPE;
   readonly controlId: NgrxFormControlId;
 
@@ -334,5 +336,5 @@ export type Actions<TValue> =
   ;
 
 export function isNgrxFormsAction(action: Action) {
-  return action.type && action.type.startsWith('ngrx/forms/');
+  return action.type && action.type.startsWith(`${ngrxFormsActionPrefix}/`);
 }

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -2,7 +2,7 @@ import { Action } from '@ngrx/store';
 import { ValidationErrors } from '@angular/forms';
 import { NgrxFormControlId, KeyValue } from './state';
 
-export const ngrxFormsActionPrefix = 'ngrx/forms';
+const ngrxFormsActionPrefix = 'ngrx/forms';
 
 export class SetValueAction<TValue> implements Action {
   static readonly TYPE = `${ngrxFormsActionPrefix}/SET_VALUE`;

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -335,6 +335,6 @@ export type Actions<TValue> =
   | ResetAction
   ;
 
-export function isNgrxFormsAction(action: Action) {
-  return action.type && action.type.startsWith(`${ngrxFormsActionPrefix}/`);
+export function isNgrxFormsAction(action: Action): boolean {
+  return !!action.type && action.type.startsWith(`${ngrxFormsActionPrefix}/`);
 }

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -2,7 +2,7 @@ import { Action } from '@ngrx/store';
 import { ValidationErrors } from '@angular/forms';
 import { NgrxFormControlId, KeyValue } from './state';
 
-const ngrxFormsActionPrefix = 'ngrx/forms';
+export const ngrxFormsActionPrefix = 'ngrx/forms';
 
 export class SetValueAction<TValue> implements Action {
   static readonly TYPE = `${ngrxFormsActionPrefix}/SET_VALUE`;

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -2,10 +2,8 @@ import { Action } from '@ngrx/store';
 import { ValidationErrors } from '@angular/forms';
 import { NgrxFormControlId, KeyValue } from './state';
 
-export const ngrxFormsActionPrefix = 'ngrx/forms';
-
 export class SetValueAction<TValue> implements Action {
-  static readonly TYPE = `${ngrxFormsActionPrefix}/SET_VALUE`;
+  static readonly TYPE = 'ngrx/forms/SET_VALUE';
   readonly type = SetValueAction.TYPE;
   readonly controlId: NgrxFormControlId;
 
@@ -23,7 +21,7 @@ export class SetValueAction<TValue> implements Action {
 }
 
 export class SetErrorsAction implements Action {
-  static readonly TYPE = `${ngrxFormsActionPrefix}/SET_ERRORS`;
+  static readonly TYPE = 'ngrx/forms/SET_ERRORS';
   readonly type = SetErrorsAction.TYPE;
   readonly controlId: NgrxFormControlId;
 
@@ -43,7 +41,7 @@ export class SetErrorsAction implements Action {
 }
 
 export class SetAsyncErrorAction implements Action {
-  static readonly TYPE = `${ngrxFormsActionPrefix}/SET_ASYNC_ERROR`;
+  static readonly TYPE = 'ngrx/forms/SET_ASYNC_ERROR';
   readonly type = SetAsyncErrorAction.TYPE;
   readonly controlId: NgrxFormControlId;
 
@@ -66,7 +64,7 @@ export class SetAsyncErrorAction implements Action {
 }
 
 export class ClearAsyncErrorAction implements Action {
-  static readonly TYPE = `${ngrxFormsActionPrefix}/CLEAR_ASYNC_ERROR`;
+  static readonly TYPE = 'ngrx/forms/CLEAR_ASYNC_ERROR';
   readonly type = ClearAsyncErrorAction.TYPE;
   readonly controlId: NgrxFormControlId;
 
@@ -86,7 +84,7 @@ export class ClearAsyncErrorAction implements Action {
 }
 
 export class StartAsyncValidationAction implements Action {
-  static readonly TYPE = `${ngrxFormsActionPrefix}/START_ASYNC_VALIDATION`;
+  static readonly TYPE = 'ngrx/forms/START_ASYNC_VALIDATION';
   readonly type = StartAsyncValidationAction.TYPE;
   readonly controlId: NgrxFormControlId;
 
@@ -106,7 +104,7 @@ export class StartAsyncValidationAction implements Action {
 }
 
 export class MarkAsDirtyAction implements Action {
-  static readonly TYPE = `${ngrxFormsActionPrefix}/MARK_AS_DIRTY`;
+  static readonly TYPE = 'ngrx/forms/MARK_AS_DIRTY';
   readonly type = MarkAsDirtyAction.TYPE;
   readonly controlId: NgrxFormControlId;
 
@@ -116,7 +114,7 @@ export class MarkAsDirtyAction implements Action {
 }
 
 export class MarkAsPristineAction implements Action {
-  static readonly TYPE = `${ngrxFormsActionPrefix}/MARK_AS_PRISTINE`;
+  static readonly TYPE = 'ngrx/forms/MARK_AS_PRISTINE';
   readonly type = MarkAsPristineAction.TYPE;
   readonly controlId: NgrxFormControlId;
 
@@ -126,7 +124,7 @@ export class MarkAsPristineAction implements Action {
 }
 
 export class EnableAction implements Action {
-  static readonly TYPE = `${ngrxFormsActionPrefix}/ENABLE`;
+  static readonly TYPE = 'ngrx/forms/ENABLE';
   readonly type = EnableAction.TYPE;
   readonly controlId: NgrxFormControlId;
 
@@ -136,7 +134,7 @@ export class EnableAction implements Action {
 }
 
 export class DisableAction implements Action {
-  static readonly TYPE = `${ngrxFormsActionPrefix}/DISABLE`;
+  static readonly TYPE = 'ngrx/forms/DISABLE';
   readonly type = DisableAction.TYPE;
   readonly controlId: NgrxFormControlId;
 
@@ -146,7 +144,7 @@ export class DisableAction implements Action {
 }
 
 export class MarkAsTouchedAction implements Action {
-  static readonly TYPE = `${ngrxFormsActionPrefix}/MARK_AS_TOUCHED`;
+  static readonly TYPE = 'ngrx/forms/MARK_AS_TOUCHED';
   readonly type = MarkAsTouchedAction.TYPE;
   readonly controlId: NgrxFormControlId;
 
@@ -156,7 +154,7 @@ export class MarkAsTouchedAction implements Action {
 }
 
 export class MarkAsUntouchedAction implements Action {
-  static readonly TYPE = `${ngrxFormsActionPrefix}/MARK_AS_UNTOUCHED`;
+  static readonly TYPE = 'ngrx/forms/MARK_AS_UNTOUCHED';
   readonly type = MarkAsUntouchedAction.TYPE;
   readonly controlId: NgrxFormControlId;
 
@@ -166,7 +164,7 @@ export class MarkAsUntouchedAction implements Action {
 }
 
 export class FocusAction implements Action {
-  static readonly TYPE = `${ngrxFormsActionPrefix}/FOCUS`;
+  static readonly TYPE = 'ngrx/forms/FOCUS';
   readonly type = FocusAction.TYPE;
   readonly controlId: NgrxFormControlId;
 
@@ -176,7 +174,7 @@ export class FocusAction implements Action {
 }
 
 export class UnfocusAction implements Action {
-  static readonly TYPE = `${ngrxFormsActionPrefix}/UNFOCUS`;
+  static readonly TYPE = 'ngrx/forms/UNFOCUS';
   readonly type = UnfocusAction.TYPE;
   readonly controlId: NgrxFormControlId;
 
@@ -186,7 +184,7 @@ export class UnfocusAction implements Action {
 }
 
 export class MarkAsSubmittedAction implements Action {
-  static readonly TYPE = `${ngrxFormsActionPrefix}/MARK_AS_SUBMITTED`;
+  static readonly TYPE = 'ngrx/forms/MARK_AS_SUBMITTED';
   readonly type = MarkAsSubmittedAction.TYPE;
   readonly controlId: NgrxFormControlId;
 
@@ -196,7 +194,7 @@ export class MarkAsSubmittedAction implements Action {
 }
 
 export class MarkAsUnsubmittedAction implements Action {
-  static readonly TYPE = `${ngrxFormsActionPrefix}/MARK_AS_UNSUBMITTED`;
+  static readonly TYPE = 'ngrx/forms/MARK_AS_UNSUBMITTED';
   readonly type = MarkAsUnsubmittedAction.TYPE;
   readonly controlId: NgrxFormControlId;
 
@@ -206,7 +204,7 @@ export class MarkAsUnsubmittedAction implements Action {
 }
 
 export class AddArrayControlAction<TValue> implements Action {
-  static readonly TYPE = `${ngrxFormsActionPrefix}/ADD_ARRAY_CONTROL`;
+  static readonly TYPE = 'ngrx/forms/ADD_ARRAY_CONTROL';
   readonly type = AddArrayControlAction.TYPE;
   readonly controlId: NgrxFormControlId;
 
@@ -226,7 +224,7 @@ export class AddArrayControlAction<TValue> implements Action {
 }
 
 export class AddGroupControlAction<TValue extends KeyValue, TControlKey extends keyof TValue = string> implements Action {
-  static readonly TYPE = `${ngrxFormsActionPrefix}/ADD_GROUP_CONTROL`;
+  static readonly TYPE = 'ngrx/forms/ADD_GROUP_CONTROL';
   readonly type = AddGroupControlAction.TYPE;
   readonly controlId: NgrxFormControlId;
 
@@ -246,7 +244,7 @@ export class AddGroupControlAction<TValue extends KeyValue, TControlKey extends 
 }
 
 export class RemoveArrayControlAction implements Action {
-  static readonly TYPE = `${ngrxFormsActionPrefix}/REMOVE_ARRAY_CONTROL`;
+  static readonly TYPE = 'ngrx/forms/REMOVE_ARRAY_CONTROL';
   readonly type = RemoveArrayControlAction.TYPE;
   readonly controlId: NgrxFormControlId;
 
@@ -264,7 +262,7 @@ export class RemoveArrayControlAction implements Action {
 }
 
 export class RemoveGroupControlAction<TValue> implements Action {
-  static readonly TYPE = `${ngrxFormsActionPrefix}/REMOVE_CONTROL`;
+  static readonly TYPE = 'ngrx/forms/REMOVE_CONTROL';
   readonly type = RemoveGroupControlAction.TYPE;
   readonly controlId: NgrxFormControlId;
 
@@ -282,7 +280,7 @@ export class RemoveGroupControlAction<TValue> implements Action {
 }
 
 export class SetUserDefinedPropertyAction implements Action {
-  static readonly TYPE = `${ngrxFormsActionPrefix}/SET_USER_DEFINED_PROPERTY`;
+  static readonly TYPE = 'ngrx/forms/SET_USER_DEFINED_PROPERTY';
   readonly type = SetUserDefinedPropertyAction.TYPE;
   readonly controlId: NgrxFormControlId;
 
@@ -302,7 +300,7 @@ export class SetUserDefinedPropertyAction implements Action {
 }
 
 export class ResetAction implements Action {
-  static readonly TYPE = `${ngrxFormsActionPrefix}/RESET`;
+  static readonly TYPE = 'ngrx/forms/RESET';
   readonly type = ResetAction.TYPE;
   readonly controlId: NgrxFormControlId;
 
@@ -335,6 +333,6 @@ export type Actions<TValue> =
   | ResetAction
   ;
 
-export function isNgrxFormsAction(action: Action): boolean {
-  return !!action.type && action.type.startsWith(`${ngrxFormsActionPrefix}/`);
+export function isNgrxFormsAction(action: Action) {
+  return !!action.type && action.type.startsWith('ngrx/forms/');
 }


### PR DESCRIPTION
it happens only on specs, when you are testing for empty states to return the default state 

(example: https://github.com/ngrx/platform/blob/master/example-app/app/books/reducers/books.spec.ts#L22)