### PR TITLE
fix: recursively update nested controls IDs upon control insertion into array

### DIFF
--- a/src/array/reducer/add-control.ts
+++ b/src/array/reducer/add-control.ts
@@ -1,6 +1,6 @@
-import { Actions, AddArrayControlAction } from '../../actions';
-import { computeArrayState, createChildState, FormArrayState } from '../../state';
-import { childReducer } from './util';
+import {Actions, AddArrayControlAction} from '../../actions';
+import {computeArrayState, createChildState, FormArrayState} from '../../state';
+import {childReducer, updateIdRecursive} from './util';
 
 export function addControlReducer<TValue>(
   state: FormArrayState<TValue>,
@@ -22,7 +22,10 @@ export function addControlReducer<TValue>(
 
   let controls = [...state.controls];
   controls.splice(index, 0, createChildState(`${state.id}.${index}`, action.payload.value));
-  controls = controls.map((c, i) => ({ ...c, id: `${state.id}.${i}` }));
+
+  // Deep update IDs of subsequent controls in the formArray
+  controls = controls.map((c, i) =>
+    i >= index ? updateIdRecursive(c, `${state.id}.${i}`) : c);
 
   return computeArrayState(
     state.id,

--- a/src/array/reducer/remove-control.ts
+++ b/src/array/reducer/remove-control.ts
@@ -1,48 +1,6 @@
-import { Actions, RemoveArrayControlAction } from '../../actions';
-import { AbstractControlState, computeArrayState, FormArrayState, FormGroupState, FormGroupControls, isArrayState, isGroupState } from '../../state';
-import { childReducer } from './util';
-
-function updateIdRecursiveForGroup(state: FormGroupState<any>, newId: string) {
-  const controls: FormGroupControls<any> =
-    Object.keys(state.controls).reduce((agg, key) => Object.assign(agg, {
-      [key]: updateIdRecursive(state.controls[key], `${newId}.${key}`),
-    }), {});
-
-  return {
-    ...state,
-    id: newId,
-    controls,
-  };
-}
-
-function updateIdRecursiveForArray(state: FormArrayState<any>, newId: string) {
-  const controls = state.controls.map((c, i) => updateIdRecursive(c, `${newId}.${i}`));
-
-  return {
-    ...state,
-    id: newId,
-    controls,
-  };
-}
-
-function updateIdRecursive(state: AbstractControlState<any>, newId: string): AbstractControlState<any> {
-  if (state.id === newId) {
-    return state;
-  }
-
-  if (isGroupState(state)) {
-    return updateIdRecursiveForGroup(state, newId);
-  }
-
-  if (isArrayState(state)) {
-    return updateIdRecursiveForArray(state, newId);
-  }
-
-  return {
-    ...state,
-    id: newId,
-  };
-}
+import {Actions, RemoveArrayControlAction} from '../../actions';
+import {computeArrayState, FormArrayState} from '../../state';
+import {childReducer, updateIdRecursive} from './util';
 
 export function removeControlReducer<TValue>(
   state: FormArrayState<TValue>,

--- a/src/array/reducer/test-util.ts
+++ b/src/array/reducer/test-util.ts
@@ -1,4 +1,4 @@
-import { AbstractControlState, createFormArrayState, isArrayState, isGroupState } from '../../state';
+import {AbstractControlState, createFormArrayState, isArrayState, isGroupState} from '../../state';
 
 export const FORM_CONTROL_ID = 'test ID';
 export const FORM_CONTROL_0_ID = FORM_CONTROL_ID + '.0';
@@ -9,6 +9,33 @@ export const INITIAL_FORM_ARRAY_VALUE_NESTED_ARRAY = [[''], ['']];
 export const INITIAL_STATE = createFormArrayState(FORM_CONTROL_ID, INITIAL_FORM_ARRAY_VALUE);
 export const INITIAL_STATE_NESTED_GROUP = createFormArrayState(FORM_CONTROL_ID, INITIAL_FORM_ARRAY_VALUE_NESTED_GROUP);
 export const INITIAL_STATE_NESTED_ARRAY = createFormArrayState(FORM_CONTROL_ID, INITIAL_FORM_ARRAY_VALUE_NESTED_ARRAY);
+
+export interface IInitialFormArrayValueDeeplyNestedGroup {
+  i: string;
+  deep: { inners: Array<{ inner: string }> };
+}
+
+export const INITIAL_FORM_ARRAY_VALUE_DEEPLY_NESTED_GROUPS: IInitialFormArrayValueDeeplyNestedGroup[] = [
+  {
+    i: '0',
+    deep: {
+      inners: [{inner: 'inner-0-0'}, {inner: 'inner-0-1'}],
+    },
+  },
+  {
+    i: '1',
+    deep: {
+      inners: [{inner: 'inner-1-0'}, {inner: 'inner-1-1'}, {inner: 'inner-1-2'}],
+    },
+  },
+  {
+    i: '2',
+    deep: {
+      inners: [{inner: 'inner-2-0'}],
+    },
+  },
+];
+export const INITIAL_FORM_ARRAY_STATE_DEEPLY_NESTED_GROUPS = createFormArrayState(FORM_CONTROL_ID, INITIAL_FORM_ARRAY_VALUE_DEEPLY_NESTED_GROUPS);
 
 export const setPropertyRecursively = <TValue>(
   state: AbstractControlState<TValue>,

--- a/src/array/reducer/util.ts
+++ b/src/array/reducer/util.ts
@@ -1,8 +1,8 @@
-import { Actions } from '../../actions';
-import { formControlReducerInternal } from '../../control/reducer';
-import { formGroupReducerInternal } from '../../group/reducer';
-import { AbstractControlState, computeArrayState, FormArrayState, isArrayState, isGroupState } from '../../state';
-import { formArrayReducerInternal } from '../reducer';
+import {Actions} from '../../actions';
+import {formControlReducerInternal} from '../../control/reducer';
+import {formGroupReducerInternal} from '../../group/reducer';
+import {AbstractControlState, computeArrayState, FormArrayState, FormGroupControls, FormGroupState, isArrayState, isGroupState, KeyValue} from '../../state';
+import {formArrayReducerInternal} from '../reducer';
 
 export function callChildReducer(
   state: AbstractControlState<any>,
@@ -55,4 +55,46 @@ export function childReducer<TValue>(state: FormArrayState<TValue>, action: Acti
   }
 
   return computeArrayState(state.id, controls, state.value, state.errors, state.pendingValidations, state.userDefinedProperties);
+}
+
+export function updateIdRecursiveForGroup<TValue extends KeyValue>(state: FormGroupState<TValue>, newId: string): FormGroupState<TValue> {
+  const controls: FormGroupControls<TValue> =
+    Object.keys(state.controls).reduce((agg, key) => Object.assign(agg, {
+      [key]: updateIdRecursive(state.controls[key], `${newId}.${key}`),
+    }), {} as FormGroupControls<TValue>);
+
+  return {
+    ...state,
+    id: newId,
+    controls,
+  };
+}
+
+export function updateIdRecursiveForArray<TValue>(state: FormArrayState<TValue>, newId: string): FormArrayState<TValue> {
+  const controls = state.controls.map((c, i) => updateIdRecursive(c, `${newId}.${i}`));
+
+  return {
+    ...state,
+    id: newId,
+    controls,
+  };
+}
+
+export function updateIdRecursive(state: AbstractControlState<any>, newId: string): AbstractControlState<any> {
+  if (state.id === newId) {
+    return state;
+  }
+
+  if (isGroupState(state)) {
+    return updateIdRecursiveForGroup(state, newId);
+  }
+
+  if (isArrayState(state)) {
+    return updateIdRecursiveForArray(state, newId);
+  }
+
+  return {
+    ...state,
+    id: newId,
+  };
 }


### PR DESCRIPTION
This pull request contains a fix for a bug in ngrx-forms where deeply nested control IDs in a FormArray were not properly updated upon an insertion into the array. 

My fix looks for all controls after the newly inserted control, then deeply updates their children's ids (using the recursive ID update function previously located in the Removearraycontrol reducer, now moved to reducers/utils). I have also enriched the tests with a slightly more complex state and a deep check for nested ids.

Here is a small practical example of the changes.

```typescript    

const action = new AddArrayControlAction<{ inner: string }>(FORM_CONTROL_ID, {inner: 'new'}, 0);
const resultState = addControlReducer<{ inner: string }>(INITIAL_STATE_NESTED_GROUP, action);
console.log(resultState.controls);

/** 
As you can see below, the inner control's IDs are out of sync 
with their actual position in the array. 
They are also duplicated, with the newly inserted item having 
the same control ID as the item that used to be in its previous position.
**/

// BEFORE FIX

[
  {
    "id": "test ID.0",
    "controls": {
      "inner": {
        "id": "test ID.0.inner",
      }
    }
  },
  {
    "id": "test ID.1",
    "controls": {
      "inner": {
        "id": "test ID.0.inner",
      }
    }
  },
  {
    "id": "test ID.2",
    "controls": {
      "inner": {
        "id": "test ID.1.inner",
      }
    }
  }
]


// AFTER FIX

[
  {
    "id": "test ID.0",
    "controls": {
      "inner": {
        "id": "test ID.0.inner",
      }
    }
  },
  {
    "id": "test ID.1",
    "controls": {
      "inner": {
        "id": "test ID.1.inner",
      }
    }
  },
  {
    "id": "test ID.2",
    "controls": {
      "inner": {
        "id": "test ID.2.inner",
      }
    }
  }
]

```

