### PR TITLE
[New Feature] Move / Swap array controls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ $ cat .gitignore
 
 *.log
 /*.tgz
+.idea/

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1,6 +1,6 @@
-import { Action } from '@ngrx/store';
-import { ValidationErrors } from '@angular/forms';
-import { NgrxFormControlId, KeyValue } from './state';
+import {Action} from '@ngrx/store';
+import {ValidationErrors} from '@angular/forms';
+import {KeyValue, NgrxFormControlId} from './state';
 
 export class SetValueAction<TValue> implements Action {
   static readonly TYPE = 'ngrx/forms/SET_VALUE';
@@ -16,7 +16,7 @@ export class SetValueAction<TValue> implements Action {
     value: TValue,
   ) {
     this.controlId = controlId;
-    this.payload = { value };
+    this.payload = {value};
   }
 }
 
@@ -219,7 +219,7 @@ export class AddArrayControlAction<TValue> implements Action {
     index: number | null = null,
   ) {
     this.controlId = controlId;
-    this.payload = { index, value };
+    this.payload = {index, value};
   }
 }
 
@@ -239,7 +239,7 @@ export class AddGroupControlAction<TValue extends KeyValue, TControlKey extends 
     value: TValue[TControlKey],
   ) {
     this.controlId = controlId;
-    this.payload = { name, value };
+    this.payload = {name, value};
   }
 }
 
@@ -257,7 +257,61 @@ export class RemoveArrayControlAction implements Action {
     index: number,
   ) {
     this.controlId = controlId;
-    this.payload = { index };
+    this.payload = {index};
+  }
+}
+
+export class SwapArrayControlAction implements Action {
+  static readonly TYPE = 'ngrx/forms/SWAP_ARRAY_CONTROL';
+  readonly type = SwapArrayControlAction.TYPE;
+  readonly controlId: NgrxFormControlId;
+
+  readonly payload: {
+    readonly from: number;
+    readonly to: number;
+  };
+
+  constructor(
+    controlId: string,
+    from: number,
+    to: number
+  ) {
+    if (from === to) {
+      throw new Error('Swap indices cannot be equal');
+    }
+    if (from < 0 || to < 0) {
+      throw new Error('Swap indices cannot be negative.');
+    }
+
+    this.controlId = controlId;
+    this.payload = {from, to};
+  }
+}
+
+export class MoveArrayControlAction implements Action {
+  static readonly TYPE = 'ngrx/forms/MOVE_ARRAY_CONTROL';
+  readonly type = MoveArrayControlAction.TYPE;
+  readonly controlId: NgrxFormControlId;
+
+  readonly payload: {
+    readonly from: number;
+    readonly to: number;
+  };
+
+  constructor(
+    controlId: string,
+    from: number,
+    to: number
+  ) {
+    if (from === to) {
+      throw new Error('Move indices cannot be equal');
+    }
+    if (from < 0 || to < 0) {
+      throw new Error('Move indices cannot be negative.');
+    }
+
+    this.controlId = controlId;
+    this.payload = {from, to};
   }
 }
 
@@ -275,7 +329,7 @@ export class RemoveGroupControlAction<TValue> implements Action {
     name: keyof TValue,
   ) {
     this.controlId = controlId;
-    this.payload = { name };
+    this.payload = {name};
   }
 }
 
@@ -295,7 +349,7 @@ export class SetUserDefinedPropertyAction implements Action {
     value: any,
   ) {
     this.controlId = controlId;
-    this.payload = { name, value };
+    this.payload = {name, value};
   }
 }
 
@@ -331,6 +385,8 @@ export type Actions<TValue> =
   | RemoveArrayControlAction
   | SetUserDefinedPropertyAction
   | ResetAction
+  | SwapArrayControlAction
+  | MoveArrayControlAction
   ;
 
 export function isNgrxFormsAction(action: Action) {

--- a/src/array/reducer.ts
+++ b/src/array/reducer.ts
@@ -1,32 +1,27 @@
-import { Action } from '@ngrx/store';
+import {Action} from '@ngrx/store';
 
-import {
-  Actions,
-  AddGroupControlAction,
-  FocusAction,
-  isNgrxFormsAction,
-  RemoveGroupControlAction,
-  UnfocusAction,
-} from '../actions';
-import { FormArrayState, isArrayState } from '../state';
-import { addControlReducer } from './reducer/add-control';
-import { clearAsyncErrorReducer } from './reducer/clear-async-error';
-import { disableReducer } from './reducer/disable';
-import { enableReducer } from './reducer/enable';
-import { markAsDirtyReducer } from './reducer/mark-as-dirty';
-import { markAsPristineReducer } from './reducer/mark-as-pristine';
-import { markAsSubmittedReducer } from './reducer/mark-as-submitted';
-import { markAsTouchedReducer } from './reducer/mark-as-touched';
-import { markAsUnsubmittedReducer } from './reducer/mark-as-unsubmitted';
-import { markAsUntouchedReducer } from './reducer/mark-as-untouched';
-import { removeControlReducer } from './reducer/remove-control';
-import { resetReducer } from './reducer/reset';
-import { setAsyncErrorReducer } from './reducer/set-async-error';
-import { setErrorsReducer } from './reducer/set-errors';
-import { setUserDefinedPropertyReducer } from './reducer/set-user-defined-property';
-import { setValueReducer } from './reducer/set-value';
-import { startAsyncValidationReducer } from './reducer/start-async-validation';
-import { childReducer } from './reducer/util';
+import {Actions, AddGroupControlAction, FocusAction, isNgrxFormsAction, RemoveGroupControlAction, UnfocusAction} from '../actions';
+import {FormArrayState, isArrayState} from '../state';
+import {addControlReducer} from './reducer/add-control';
+import {clearAsyncErrorReducer} from './reducer/clear-async-error';
+import {disableReducer} from './reducer/disable';
+import {enableReducer} from './reducer/enable';
+import {markAsDirtyReducer} from './reducer/mark-as-dirty';
+import {markAsPristineReducer} from './reducer/mark-as-pristine';
+import {markAsSubmittedReducer} from './reducer/mark-as-submitted';
+import {markAsTouchedReducer} from './reducer/mark-as-touched';
+import {markAsUnsubmittedReducer} from './reducer/mark-as-unsubmitted';
+import {markAsUntouchedReducer} from './reducer/mark-as-untouched';
+import {removeControlReducer} from './reducer/remove-control';
+import {resetReducer} from './reducer/reset';
+import {setAsyncErrorReducer} from './reducer/set-async-error';
+import {setErrorsReducer} from './reducer/set-errors';
+import {setUserDefinedPropertyReducer} from './reducer/set-user-defined-property';
+import {setValueReducer} from './reducer/set-value';
+import {startAsyncValidationReducer} from './reducer/start-async-validation';
+import {childReducer} from './reducer/util';
+import {swapControlReducer} from './reducer/swap-control';
+import {moveControlReducer} from './reducer/move-control';
 
 export function formArrayReducerInternal<TValue>(state: FormArrayState<TValue>, action: Actions<TValue[]>) {
   if (!isArrayState(state)) {
@@ -66,6 +61,8 @@ export function formArrayReducerInternal<TValue>(state: FormArrayState<TValue>, 
   state = resetReducer(state, action);
   state = addControlReducer(state, action);
   state = removeControlReducer(state, action);
+  state = swapControlReducer(state, action);
+  state = moveControlReducer(state, action);
 
   return state;
 }

--- a/src/array/reducer/move-control.spec.ts
+++ b/src/array/reducer/move-control.spec.ts
@@ -1,0 +1,56 @@
+import {MoveArrayControlAction} from '../../actions';
+import {cast, createFormArrayState} from '../../state';
+import {FORM_CONTROL_ID, INITIAL_FORM_ARRAY_STATE_DEEPLY_NESTED_GROUPS, INITIAL_STATE_NESTED_GROUP} from './test-util';
+import {moveControlReducer} from './move-control';
+
+describe(`form array move`, () => {
+  const testArrayValue = [0, 1, 2, 3, 4, 5];
+  const testArrayState = createFormArrayState(FORM_CONTROL_ID, testArrayValue);
+  it('should move controls forward', () => {
+    let action = new MoveArrayControlAction(FORM_CONTROL_ID, 2, 5);
+    let resultState = moveControlReducer(testArrayState, action);
+    expect(resultState).not.toBe(testArrayState);
+    expect(resultState.controls).not.toBe(testArrayState.controls);
+    expect(resultState.value).toEqual([0, 1, 3, 4, 5, 2]);
+
+    action = new MoveArrayControlAction(FORM_CONTROL_ID, 0, 3);
+    resultState = moveControlReducer(testArrayState, action);
+    expect(resultState.value).toEqual([1, 2, 3, 0, 4, 5]);
+  });
+
+  it('should move controls backwards', () => {
+    let action = new MoveArrayControlAction(FORM_CONTROL_ID, 5, 2);
+    let resultState = moveControlReducer(testArrayState, action);
+    expect(resultState).not.toBe(testArrayState);
+    expect(resultState.controls).not.toBe(testArrayState.controls);
+    expect(resultState.value).toEqual([0, 1, 5, 2, 3, 4]);
+
+    action = new MoveArrayControlAction(FORM_CONTROL_ID, 3, 0);
+    resultState = moveControlReducer(testArrayState, action);
+    expect(resultState.value).toEqual([3, 0, 1, 2, 4, 5]);
+  });
+
+  it('should throw on invalid indices', () => {
+    expect(() => new MoveArrayControlAction(FORM_CONTROL_ID, -1, 0)).toThrow();
+    expect(() =>
+      moveControlReducer(
+        INITIAL_STATE_NESTED_GROUP,
+        new MoveArrayControlAction(FORM_CONTROL_ID, -1, INITIAL_STATE_NESTED_GROUP.controls.length + 1))
+    ).toThrow();
+  });
+
+  it('should update deeply nested child IDs after a move', () => {
+    const action = new MoveArrayControlAction(FORM_CONTROL_ID, 0, 2);
+    const resultState = moveControlReducer(INITIAL_FORM_ARRAY_STATE_DEEPLY_NESTED_GROUPS, action);
+    resultState.controls.forEach((control, index) => {
+      expect(control.id).toEqual(FORM_CONTROL_ID + `.${index}`);
+      expect(cast(control).controls.i.id).toEqual(FORM_CONTROL_ID + `.${index}.i`);
+      expect(cast(control).controls.deep.id).toEqual(FORM_CONTROL_ID + `.${index}.deep`);
+      expect(cast(cast(control).controls.deep).controls.inners.id).toEqual(FORM_CONTROL_ID + `.${index}.deep.inners`);
+      cast(cast(cast(control).controls.deep).controls.inners).controls.forEach((deepControl, deepIndex) => {
+        expect(deepControl.id).toEqual(FORM_CONTROL_ID + `.${index}.deep.inners.${deepIndex}`);
+        expect(cast<{ inner: string }>(deepControl).controls.inner.id).toEqual(FORM_CONTROL_ID + `.${index}.deep.inners.${deepIndex}.inner`);
+      });
+    });
+  });
+});

--- a/src/array/reducer/move-control.ts
+++ b/src/array/reducer/move-control.ts
@@ -1,0 +1,58 @@
+import {Actions, MoveArrayControlAction} from '../../actions';
+import {computeArrayState, FormArrayState} from '../../state';
+import {childReducer, updateIdRecursive} from './util';
+
+export function move(array: any[], from: number, to: number) {
+  const item = array[from];
+  const length = array.length;
+  const diff = from - to;
+  if (diff > 0) {
+    return [
+      ...array.slice(0, to),
+      item,
+      ...array.slice(to, from),
+      ...array.slice(from + 1, length),
+    ];
+  } else if (diff < 0) {
+    const targetIndex = to + 1;
+    return [
+      ...array.slice(0, from),
+      ...array.slice(from + 1, targetIndex),
+      item,
+      ...array.slice(targetIndex, length),
+    ];
+  }
+  return array;
+}
+
+export function moveControlReducer<TValue>(
+  state: FormArrayState<TValue>,
+  action: Actions<TValue[]>,
+): FormArrayState<TValue> {
+  if (action.type !== MoveArrayControlAction.TYPE) {
+    return state;
+  }
+  const from = action.payload.from;
+  const to = action.payload.to;
+
+  if (action.controlId !== state.id) {
+    return childReducer(state, action);
+  }
+
+  if (from >= state.controls.length || to >= state.controls.length) {
+    throw new Error(`Index ${from >= state.controls.length ? from : to} is out of bounds for array '${state.id}' with length ${state.controls.length}!`); // `;
+  }
+
+  let controls = move(state.controls, from, to);
+
+  controls = controls.map((c, i) => (i >= from || i >= to) ? updateIdRecursive(c, `${state.id}.${i}`) : c);
+
+  return computeArrayState(
+    state.id,
+    controls,
+    state.value,
+    state.errors,
+    state.pendingValidations,
+    state.userDefinedProperties,
+  );
+}

--- a/src/array/reducer/swap-control.spec.ts
+++ b/src/array/reducer/swap-control.spec.ts
@@ -1,0 +1,53 @@
+import {SwapArrayControlAction} from '../../actions';
+import {cast} from '../../state';
+import {
+  FORM_CONTROL_ID,
+  INITIAL_FORM_ARRAY_STATE_DEEPLY_NESTED_GROUPS,
+  INITIAL_FORM_ARRAY_VALUE_DEEPLY_NESTED_GROUPS,
+  INITIAL_STATE_NESTED_GROUP
+} from './test-util';
+import {swapControlReducer} from './swap-control';
+
+describe(`form array swap`, () => {
+  it('should swap controls forwards', () => {
+    const action = new SwapArrayControlAction(FORM_CONTROL_ID, 0, 2);
+    const expectedValue = [...INITIAL_FORM_ARRAY_VALUE_DEEPLY_NESTED_GROUPS];
+    expectedValue[0] = INITIAL_FORM_ARRAY_VALUE_DEEPLY_NESTED_GROUPS[2];
+    expectedValue[2] = INITIAL_FORM_ARRAY_VALUE_DEEPLY_NESTED_GROUPS[0];
+    const resultState = swapControlReducer(INITIAL_FORM_ARRAY_STATE_DEEPLY_NESTED_GROUPS, action);
+    expect(expectedValue).toEqual(resultState.value);
+  });
+
+  it('should swap controls backwards', () => {
+    const action = new SwapArrayControlAction(FORM_CONTROL_ID, 2, 0);
+    const expectedValue = [...INITIAL_FORM_ARRAY_VALUE_DEEPLY_NESTED_GROUPS];
+    expectedValue[2] = INITIAL_FORM_ARRAY_VALUE_DEEPLY_NESTED_GROUPS[0];
+    expectedValue[0] = INITIAL_FORM_ARRAY_VALUE_DEEPLY_NESTED_GROUPS[2];
+    const resultState = swapControlReducer(INITIAL_FORM_ARRAY_STATE_DEEPLY_NESTED_GROUPS, action);
+    expect(expectedValue).toEqual(resultState.value);
+  });
+
+  it('should throw on invalid indices', () => {
+    expect(() => new SwapArrayControlAction(FORM_CONTROL_ID, -1, 0)).toThrow();
+    expect(() => new SwapArrayControlAction(FORM_CONTROL_ID, 0, -1)).toThrow();
+    expect(() => swapControlReducer(
+      INITIAL_STATE_NESTED_GROUP,
+      new SwapArrayControlAction(FORM_CONTROL_ID, 0, INITIAL_STATE_NESTED_GROUP.controls.length + 1))
+    ).toThrow();
+  });
+
+  it('should update deeply nested child IDs after a swap', () => {
+    const action = new SwapArrayControlAction(FORM_CONTROL_ID, 0, 2);
+    const resultState = swapControlReducer(INITIAL_FORM_ARRAY_STATE_DEEPLY_NESTED_GROUPS, action);
+    resultState.controls.forEach((control, index) => {
+      expect(control.id).toEqual(FORM_CONTROL_ID + `.${index}`);
+      expect(cast(control).controls.i.id).toEqual(FORM_CONTROL_ID + `.${index}.i`);
+      expect(cast(control).controls.deep.id).toEqual(FORM_CONTROL_ID + `.${index}.deep`);
+      expect(cast(cast(control).controls.deep).controls.inners.id).toEqual(FORM_CONTROL_ID + `.${index}.deep.inners`);
+      cast(cast(cast(control).controls.deep).controls.inners).controls.forEach((deepControl, deepIndex) => {
+        expect(deepControl.id).toEqual(FORM_CONTROL_ID + `.${index}.deep.inners.${deepIndex}`);
+        expect(cast<{ inner: string }>(deepControl).controls.inner.id).toEqual(FORM_CONTROL_ID + `.${index}.deep.inners.${deepIndex}.inner`);
+      });
+    });
+  });
+});

--- a/src/array/reducer/swap-control.ts
+++ b/src/array/reducer/swap-control.ts
@@ -1,0 +1,42 @@
+import {Actions, SwapArrayControlAction} from '../../actions';
+import {computeArrayState, FormArrayState} from '../../state';
+import {childReducer, updateIdRecursive} from './util';
+
+function swapArrayValues(a: any[], i: number, j: number) {
+  const n = [...a];
+  [n[i], n[j]] = [n[j], n[i]];
+  return n;
+}
+
+export function swapControlReducer<TValue>(
+  state: FormArrayState<TValue>,
+  action: Actions<TValue[]>,
+): FormArrayState<TValue> {
+  if (action.type !== SwapArrayControlAction.TYPE) {
+    return state;
+  }
+  const from = action.payload.from;
+  const to = action.payload.to;
+
+  if (action.controlId !== state.id) {
+    return childReducer(state, action);
+  }
+
+  if (from >= state.controls.length || to >= state.controls.length) {
+    throw new Error(`Index [${from >= state.controls.length ? 'from:' + from : 'to:' + to}]
+     is out of bounds for array '${state.id}' with length ${state.controls.length}!`);
+  }
+
+  let controls = swapArrayValues(state.controls, from, to);
+  controls = controls.map((c, i) => (i >= from || i >= to) ? updateIdRecursive(c, `${state.id}.${i}`) : c);
+
+  // Deep update IDs of subsequent controls in the formArray
+  return computeArrayState(
+    state.id,
+    controls,
+    state.value,
+    state.errors,
+    state.pendingValidations,
+    state.userDefinedProperties,
+  );
+}

--- a/src/update-function/move-array-control.spec.ts
+++ b/src/update-function/move-array-control.spec.ts
@@ -1,0 +1,23 @@
+import {cast, createFormArrayState} from '../state';
+import {FORM_CONTROL_ID} from './test-util';
+import {moveArrayControl} from './move-array-control';
+
+describe('moveArrayControl', () => {
+  const INITIAL_ARRAY_STATE = createFormArrayState(FORM_CONTROL_ID, [0, 1, 2, 3]);
+
+  it('should call reducer for arrays', () => {
+    const resultState = moveArrayControl<number>(1, 0)(INITIAL_ARRAY_STATE);
+    expect(resultState).not.toBe(cast(INITIAL_ARRAY_STATE));
+    expect(resultState.value).toEqual([1, 0, 2, 3]);
+  });
+
+  it('should call reducer for arrays uncurried', () => {
+    const resultState = moveArrayControl<number>(0, 2, INITIAL_ARRAY_STATE);
+    expect(resultState).not.toBe(cast(INITIAL_ARRAY_STATE));
+    expect(resultState.value).toEqual([1, 2, 0, 3]);
+  });
+
+  it('should throw if curried and no state', () => {
+    expect(() => moveArrayControl<number>(0, 1)(undefined as any)).toThrowError();
+  });
+});

--- a/src/update-function/move-array-control.ts
+++ b/src/update-function/move-array-control.ts
@@ -1,0 +1,24 @@
+import {MoveArrayControlAction} from '../actions';
+import {formArrayReducer} from '../array/reducer';
+import {FormArrayState} from '../state';
+import {ensureState} from './util';
+
+/**
+ * This update function takes a source index, a destination index, and returns a projection function
+ * that move the child controls at the source index to the destination index from a form array state.
+ */
+export function moveArrayControl<TValue>(from: number, to: number): (state: FormArrayState<TValue>) => FormArrayState<TValue>;
+
+/**
+ * This update function takes a source index, a destination index, an form array state, and moves the
+ * child controls at the source index to the destination index in the form array state.
+ */
+export function moveArrayControl<TValue>(from: number, to: number, state: FormArrayState<TValue>): FormArrayState<TValue>;
+
+export function moveArrayControl<TValue>(from: number, to: number, state?: FormArrayState<TValue>) {
+  if (!!state) {
+    return formArrayReducer(state, new MoveArrayControlAction(state.id, from, to));
+  }
+
+  return (s: FormArrayState<TValue>) => moveArrayControl(from, to, ensureState(s));
+}

--- a/src/update-function/swap-array-control.spec.ts
+++ b/src/update-function/swap-array-control.spec.ts
@@ -1,0 +1,23 @@
+import {cast, createFormArrayState} from '../state';
+import {FORM_CONTROL_ID} from './test-util';
+import {swapArrayControl} from './swap-array-control';
+
+describe('swapArrayControl', () => {
+  const INITIAL_ARRAY_STATE = createFormArrayState(FORM_CONTROL_ID, [0, 1, 2, 3]);
+
+  it('should call reducer for arrays', () => {
+    const resultState = swapArrayControl<number>(1, 2)(INITIAL_ARRAY_STATE);
+    expect(resultState).not.toBe(cast(INITIAL_ARRAY_STATE));
+    expect(resultState.value).toEqual([0, 2, 1, 3]);
+  });
+
+  it('should call reducer for arrays uncurried', () => {
+    const resultState = swapArrayControl<number>(3, 1, INITIAL_ARRAY_STATE);
+    expect(resultState).not.toBe(cast(INITIAL_ARRAY_STATE));
+    expect(resultState.value).toEqual([0, 3, 2, 1]);
+  });
+
+  it('should throw if curried and no state', () => {
+    expect(() => swapArrayControl<number>(0, 1)(undefined as any)).toThrowError();
+  });
+});

--- a/src/update-function/swap-array-control.ts
+++ b/src/update-function/swap-array-control.ts
@@ -1,0 +1,24 @@
+import {SwapArrayControlAction} from '../actions';
+import {formArrayReducer} from '../array/reducer';
+import {FormArrayState} from '../state';
+import {ensureState} from './util';
+
+/**
+ * This update function takes an index and returns a projection function
+ * that swaps the child controls at the source and destination indices in a form array state.
+ */
+export function swapArrayControl<TValue>(from: number, to: number): (state: FormArrayState<TValue>) => FormArrayState<TValue>;
+
+/**
+ * This update function takes a source index, a destination index, an form array state, and swap the
+ * child controls at the source and destination indices in the form array state.
+ */
+export function swapArrayControl<TValue>(from: number, to: number, state: FormArrayState<TValue>): FormArrayState<TValue>;
+
+export function swapArrayControl<TValue>(from: number, to: number, state?: FormArrayState<TValue>) {
+  if (!!state) {
+    return formArrayReducer(state, new SwapArrayControlAction(state.id, from, to));
+  }
+
+  return (s: FormArrayState<TValue>) => swapArrayControl(from, to, ensureState(s));
+}


### PR DESCRIPTION
This pull request adds two new actions, update functions and reducers to ngrx-forms: SwapArrayControlAction and MoveArrayControlAction.

Modeled after similar actions present in [redux-form](https://redux-form.com/7.3.0/docs/api/fieldarray.md/#-code-fields-swap-indexa-integer-indexb-integer-function-code-), they allow the user to manipulate the order of form arrays a bit more conveniently. 
These two actions are especially useful in the context of reordering form controls (for example, within a drag-and-drop scenario).

The usage is straightforward:
```typescript
const val = [0,1,2,3,4,5];

const formState = createFormArrayState(FORM_CONTROL_ID, [0, 1, 2, 3]);
    
const swapped = swapArrayControl(0, 3)(formState);  // swapped = [3, 1, 2, 0]
    
const moved = moveArrayControl(0, 3)(formState);    // moved = [1, 2, 3, 0]
    
const movedBackwards = moveArrayControl(3, 0)(formState);   // movedBackwards = [3, 0, 1, 2]
```


I have included tests and documentation in the PR. 
I hope some other people will find this feature useful.