### PR TITLE
[New Feature] Add SwapArrayControl and MoveArrayControl actions

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -174,6 +174,36 @@ export class RemoveArrayControlAction implements Action {
   ) { }
 }
 
+export class SwapArrayControlAction implements Action {
+  static readonly TYPE = 'ngrx/forms/SWAP_ARRAY_CONTROL';
+  readonly type = SwapArrayControlAction.TYPE;
+
+  constructor(
+      public readonly controlId: NgrxFormControlId,
+      public readonly from: number,
+      public readonly to: number
+  ) {
+    if (from < 0 || to < 0) {
+      throw new Error('Swap indices cannot be negative.');
+    }
+  }
+}
+
+export class MoveArrayControlAction implements Action {
+  static readonly TYPE = 'ngrx/forms/MOVE_ARRAY_CONTROL';
+  readonly type = MoveArrayControlAction.TYPE;
+
+  constructor(
+    public readonly controlId: NgrxFormControlId,
+    public readonly from: number,
+    public readonly to: number
+  ) {
+    if (from < 0 || to < 0) {
+      throw new Error('Move indices cannot be negative.');
+    }
+  }
+}
+
 export class RemoveGroupControlAction<TValue> implements Action {
   static readonly TYPE = 'ngrx/forms/REMOVE_CONTROL';
   readonly type = RemoveGroupControlAction.TYPE;
@@ -226,6 +256,8 @@ export type Actions<TValue> =
   | RemoveArrayControlAction
   | SetUserDefinedPropertyAction
   | ResetAction
+  | SwapArrayControlAction
+  | MoveArrayControlAction
   ;
 
 export function isNgrxFormsAction(action: Action) {

--- a/src/array/reducer.ts
+++ b/src/array/reducer.ts
@@ -1,13 +1,6 @@
 import { Action } from '@ngrx/store';
 
-import {
-  Actions,
-  AddGroupControlAction,
-  FocusAction,
-  isNgrxFormsAction,
-  RemoveGroupControlAction,
-  UnfocusAction,
-} from '../actions';
+import { Actions, AddGroupControlAction, FocusAction, isNgrxFormsAction, RemoveGroupControlAction, UnfocusAction } from '../actions';
 import { FormArrayState, isArrayState } from '../state';
 import { addControlReducer } from './reducer/add-control';
 import { clearAsyncErrorReducer } from './reducer/clear-async-error';
@@ -19,6 +12,7 @@ import { markAsSubmittedReducer } from './reducer/mark-as-submitted';
 import { markAsTouchedReducer } from './reducer/mark-as-touched';
 import { markAsUnsubmittedReducer } from './reducer/mark-as-unsubmitted';
 import { markAsUntouchedReducer } from './reducer/mark-as-untouched';
+import { moveControlReducer } from './reducer/move-control';
 import { removeControlReducer } from './reducer/remove-control';
 import { resetReducer } from './reducer/reset';
 import { setAsyncErrorReducer } from './reducer/set-async-error';
@@ -26,6 +20,7 @@ import { setErrorsReducer } from './reducer/set-errors';
 import { setUserDefinedPropertyReducer } from './reducer/set-user-defined-property';
 import { setValueReducer } from './reducer/set-value';
 import { startAsyncValidationReducer } from './reducer/start-async-validation';
+import { swapControlReducer } from './reducer/swap-control';
 import { childReducer } from './reducer/util';
 
 export function formArrayReducerInternal<TValue>(state: FormArrayState<TValue>, action: Actions<TValue[]>) {
@@ -69,6 +64,8 @@ export function formArrayReducerInternal<TValue>(state: FormArrayState<TValue>, 
   state = resetReducer(state, action);
   state = addControlReducer(state, action);
   state = removeControlReducer(state, action);
+  state = swapControlReducer(state, action);
+  state = moveControlReducer(state, action);
 
   return state;
 }

--- a/src/array/reducer/move-control.spec.ts
+++ b/src/array/reducer/move-control.spec.ts
@@ -1,0 +1,81 @@
+import { MoveArrayControlAction } from '../../actions';
+import { createFormArrayState } from '../../state';
+import { moveControlReducer } from './move-control';
+import { FORM_CONTROL_0_ID, FORM_CONTROL_ID, INITIAL_STATE_NESTED_GROUP } from './test-util';
+
+describe(`form array move`, () => {
+  const testArrayValue = [ 0, 1, 2, 3, 4, 5 ];
+  const testArrayState = createFormArrayState(FORM_CONTROL_ID, testArrayValue);
+  it('should move controls forward', () => {
+    let action = new MoveArrayControlAction(FORM_CONTROL_ID, 2, 5);
+    let resultState = moveControlReducer(testArrayState, action);
+    expect(resultState).not.toBe(testArrayState);
+    expect(resultState.controls).not.toBe(testArrayState.controls);
+    expect(resultState.value).toEqual([ 0, 1, 3, 4, 5, 2 ]);
+
+    action = new MoveArrayControlAction(FORM_CONTROL_ID, 0, 3);
+    resultState = moveControlReducer(testArrayState, action);
+    expect(resultState.value).toEqual([ 1, 2, 3, 0, 4, 5 ]);
+  });
+
+  it('should move controls backwards', () => {
+    let action = new MoveArrayControlAction(FORM_CONTROL_ID, 5, 2);
+    let resultState = moveControlReducer(testArrayState, action);
+    expect(resultState).not.toBe(testArrayState);
+    expect(resultState.controls).not.toBe(testArrayState.controls);
+    expect(resultState.value).toEqual([ 0, 1, 5, 2, 3, 4 ]);
+
+    action = new MoveArrayControlAction(FORM_CONTROL_ID, 3, 0);
+    resultState = moveControlReducer(testArrayState, action);
+    expect(resultState.value).toEqual([ 3, 0, 1, 2, 4, 5 ]);
+  });
+
+  it('should throw on out of bound or negative indices', () => {
+    expect(() => new MoveArrayControlAction(FORM_CONTROL_ID, -1, 0)).toThrow();
+    expect(() =>
+      moveControlReducer(
+        INITIAL_STATE_NESTED_GROUP,
+        new MoveArrayControlAction(FORM_CONTROL_ID, 0, INITIAL_STATE_NESTED_GROUP.controls.length))
+    ).toThrow();
+    expect(() =>
+      moveControlReducer(
+        INITIAL_STATE_NESTED_GROUP,
+        new MoveArrayControlAction(FORM_CONTROL_ID, INITIAL_STATE_NESTED_GROUP.controls.length, 0))
+    ).toThrow();
+  });
+
+  it('should return the state on a 0 move', () => {
+    const action = new MoveArrayControlAction(FORM_CONTROL_ID, 1, 1);
+    const resultState = moveControlReducer(testArrayState, action);
+    expect(resultState).toBe(testArrayState);
+  });
+
+  it('should return the state if applied on a different state ID', () => {
+    const action = new MoveArrayControlAction(FORM_CONTROL_0_ID, 0, 1);
+    const resultState = moveControlReducer(testArrayState, action);
+    expect(resultState).toBe(testArrayState);
+  });
+
+  it('should update nested group IDs after a move', () => {
+    const action = new MoveArrayControlAction(FORM_CONTROL_ID, 0, 1);
+    const resultState = moveControlReducer(INITIAL_STATE_NESTED_GROUP, action);
+    resultState.controls.forEach((control, index) => {
+      expect(control.id).toEqual(`${FORM_CONTROL_ID}.${index}`);
+      expect(control.controls.inner.id).toEqual(`${FORM_CONTROL_ID}.${index}.inner`);
+    });
+  });
+
+  it('should update nested array child IDs after a move', () => {
+    const testValue = [ {array: [ 0, 1, 2, 3 ]}, {array: [ 0, 1, 2, 3 ]} ];
+    const testState = createFormArrayState(FORM_CONTROL_ID, testValue);
+    const action = new MoveArrayControlAction(FORM_CONTROL_ID, 0, 1);
+    const resultState = moveControlReducer(testState, action);
+    resultState.controls.forEach((control, index) => {
+      expect(control.id).toEqual(`${FORM_CONTROL_ID}.${index}`);
+      expect(control.controls.array.id).toEqual(`${FORM_CONTROL_ID}.${index}.array`);
+      control.controls.array.controls.forEach((c, i) => {
+        expect(c.id).toEqual(`${FORM_CONTROL_ID}.${index}.array.${i}`);
+      });
+    });
+  });
+});

--- a/src/array/reducer/move-control.ts
+++ b/src/array/reducer/move-control.ts
@@ -1,0 +1,67 @@
+import { Actions, MoveArrayControlAction } from '../../actions';
+import { computeArrayState, FormArrayState } from '../../state';
+import { childReducer, updateIdRecursive } from './util';
+
+export function move(array: ReadonlyArray<any>, from: number, to: number) {
+  const item = array[ from ];
+  const length = array.length;
+  const diff = from - to;
+  if (diff > 0) {
+    return [
+      ...array.slice(0, to),
+      item,
+      ...array.slice(to, from),
+      ...array.slice(from + 1, length),
+    ];
+  } else {
+    const targetIndex = to + 1;
+    return [
+      ...array.slice(0, from),
+      ...array.slice(from + 1, targetIndex),
+      item,
+      ...array.slice(targetIndex, length),
+    ];
+  }
+}
+
+export function moveControlReducer<TValue>(
+  state: FormArrayState<TValue>,
+  action: Actions<TValue[]>,
+): FormArrayState<TValue> {
+  if (action.type !== MoveArrayControlAction.TYPE) {
+    return state;
+  }
+  if (action.controlId !== state.id) {
+    return childReducer(state, action);
+  }
+
+  const from = action.from;
+  const to = action.to;
+
+  if (from === to) {
+    return state;
+  }
+
+  if (from >= state.controls.length || to >= state.controls.length) {
+    throw new Error(`Index ${from >= state.controls.length ? from : to} is out of bounds for array '${state.id}' with length ${state.controls.length}!`); // `;
+  }
+
+  let controls = move(state.controls, from, to);
+
+  controls = controls.map((c, i) => (i >= from || i >= to) ? updateIdRecursive(c, `${state.id}.${i}`) : c);
+
+  return computeArrayState(
+    state.id,
+    controls,
+    state.value,
+    state.errors,
+    state.pendingValidations,
+    state.userDefinedProperties,
+    {
+      wasOrShouldBeDirty: true,
+      wasOrShouldBeEnabled: state.isEnabled,
+      wasOrShouldBeTouched: state.isTouched,
+      wasOrShouldBeSubmitted: state.isSubmitted,
+    }
+  );
+}

--- a/src/array/reducer/swap-control.spec.ts
+++ b/src/array/reducer/swap-control.spec.ts
@@ -1,0 +1,70 @@
+import { SwapArrayControlAction } from '../../actions';
+import { createFormArrayState } from '../../state';
+import { moveControlReducer } from './move-control';
+import { swapControlReducer } from './swap-control';
+import { FORM_CONTROL_0_ID, FORM_CONTROL_ID, INITIAL_STATE_NESTED_GROUP } from './test-util';
+
+describe(`form array swap`, () => {
+  const testArrayValue = [ 0, 1, 2, 3, 4, 5 ];
+  const testArrayState = createFormArrayState(FORM_CONTROL_ID, testArrayValue);
+
+  it('should swap controls forwards', () => {
+    const action = new SwapArrayControlAction(FORM_CONTROL_ID, 0, 2);
+    const resultState = swapControlReducer(testArrayState, action);
+    expect(resultState.value).toEqual([ 2, 1, 0, 3, 4, 5 ]);
+  });
+
+  it('should swap controls backwards', () => {
+    const action = new SwapArrayControlAction(FORM_CONTROL_ID, 5, 1);
+    const resultState = swapControlReducer(testArrayState, action);
+    expect(resultState.value).toEqual([ 0, 5, 2, 3, 4, 1 ]);
+  });
+
+  it('should throw on out of bound or negative indices', () => {
+    expect(() => new SwapArrayControlAction(FORM_CONTROL_ID, -1, 0)).toThrow();
+    expect(() => new SwapArrayControlAction(FORM_CONTROL_ID, 0, -1)).toThrow();
+    expect(() => swapControlReducer(
+      INITIAL_STATE_NESTED_GROUP,
+      new SwapArrayControlAction(FORM_CONTROL_ID, 0, INITIAL_STATE_NESTED_GROUP.controls.length))
+    ).toThrow();
+    expect(() => swapControlReducer(
+      INITIAL_STATE_NESTED_GROUP,
+      new SwapArrayControlAction(FORM_CONTROL_ID, INITIAL_STATE_NESTED_GROUP.controls.length, 0))
+    ).toThrow();
+  });
+
+  it('should update deeply nested child IDs after a swap', () => {
+    const action = new SwapArrayControlAction(FORM_CONTROL_ID, 0, 1);
+    const resultState = swapControlReducer(INITIAL_STATE_NESTED_GROUP, action);
+    resultState.controls.forEach((control, index) => {
+      expect(control.id).toEqual(`${FORM_CONTROL_ID}.${index}`);
+      expect(control.controls.inner.id).toEqual(`${FORM_CONTROL_ID}.${index}.inner`);
+    });
+  });
+
+  it('should return the state on a 0 move', () => {
+    const action = new SwapArrayControlAction(FORM_CONTROL_ID, 1, 1);
+    const resultState = swapControlReducer(testArrayState, action);
+    expect(resultState).toBe(testArrayState);
+  });
+
+  it('should return the state if applied on a different state ID', () => {
+    const action = new SwapArrayControlAction(FORM_CONTROL_0_ID, 0, 1);
+    const resultState = swapControlReducer(testArrayState, action);
+    expect(resultState).toBe(testArrayState);
+  });
+
+  it('should update nested array child IDs after a swap', () => {
+    const testValue = [ {array: [ 0, 1, 2, 3 ]}, {array: [ 0, 1, 2, 3 ]} ];
+    const testState = createFormArrayState(FORM_CONTROL_ID, testValue);
+    const action = new SwapArrayControlAction(FORM_CONTROL_ID, 0, 1);
+    const resultState = moveControlReducer(testState, action);
+    resultState.controls.forEach((control, index) => {
+      expect(control.id).toEqual(`${FORM_CONTROL_ID}.${index}`);
+      expect(control.controls.array.id).toEqual(`${FORM_CONTROL_ID}.${index}.array`);
+      control.controls.array.controls.forEach((c, i) => {
+        expect(c.id).toEqual(`${FORM_CONTROL_ID}.${index}.array.${i}`);
+      });
+    });
+  });
+});

--- a/src/array/reducer/swap-control.ts
+++ b/src/array/reducer/swap-control.ts
@@ -1,0 +1,52 @@
+import { Actions, SwapArrayControlAction } from '../../actions';
+import { computeArrayState, FormArrayState } from '../../state';
+import { childReducer, updateIdRecursive } from './util';
+
+function swapArrayValues(a: ReadonlyArray<any>, i: number, j: number) {
+  const n = [ ...a ];
+  [ n[ i ], n[ j ] ] = [ n[ j ], n[ i ] ];
+  return n;
+}
+
+export function swapControlReducer<TValue>(
+  state: FormArrayState<TValue>,
+  action: Actions<TValue[]>,
+): FormArrayState<TValue> {
+  if (action.type !== SwapArrayControlAction.TYPE) {
+    return state;
+  }
+
+  if (action.controlId !== state.id) {
+    return childReducer(state, action);
+  }
+
+  const from = action.from;
+  const to = action.to;
+
+  if (from === to) {
+    return state;
+  }
+
+  if (from >= state.controls.length || to >= state.controls.length) {
+    throw new Error(`Index [${from >= state.controls.length ? `from:${from}` : `to:${to}`}]
+     is out of bounds for array '${state.id}' with length ${state.controls.length}!`);
+  }
+
+  let controls = swapArrayValues(state.controls, from, to);
+  controls = controls.map((c, i) => (i >= from || i >= to) ? updateIdRecursive(c, `${state.id}.${i}`) : c);
+
+  return computeArrayState(
+    state.id,
+    controls,
+    state.value,
+    state.errors,
+    state.pendingValidations,
+    state.userDefinedProperties,
+    {
+      wasOrShouldBeDirty: true,
+      wasOrShouldBeEnabled: state.isEnabled,
+      wasOrShouldBeTouched: state.isTouched,
+      wasOrShouldBeSubmitted: state.isSubmitted,
+    }
+  );
+}

--- a/src/update-function/move-array-control.spec.ts
+++ b/src/update-function/move-array-control.spec.ts
@@ -1,0 +1,23 @@
+import { createFormArrayState } from '../state';
+import { moveArrayControl } from './move-array-control';
+import { FORM_CONTROL_ID } from './test-util';
+
+describe('moveArrayControl', () => {
+  const INITIAL_ARRAY_STATE = createFormArrayState(FORM_CONTROL_ID, [ 0, 1, 2, 3 ]);
+
+  it('should call reducer for arrays', () => {
+    const resultState = moveArrayControl<number>(1, 0)(INITIAL_ARRAY_STATE);
+    expect(resultState).not.toBe(INITIAL_ARRAY_STATE);
+    expect(resultState.value).toEqual([ 1, 0, 2, 3 ]);
+  });
+
+  it('should call reducer for arrays uncurried', () => {
+    const resultState = moveArrayControl<number>(0, 2, INITIAL_ARRAY_STATE);
+    expect(resultState).not.toBe(INITIAL_ARRAY_STATE);
+    expect(resultState.value).toEqual([ 1, 2, 0, 3 ]);
+  });
+
+  it('should throw if curried and no state', () => {
+    expect(() => moveArrayControl<number>(0, 1)(undefined as any)).toThrowError();
+  });
+});

--- a/src/update-function/move-array-control.ts
+++ b/src/update-function/move-array-control.ts
@@ -1,0 +1,24 @@
+import { MoveArrayControlAction } from '../actions';
+import { formArrayReducer } from '../array/reducer';
+import { FormArrayState } from '../state';
+import { ensureState } from './util';
+
+/**
+ * This update function takes a source index, a destination index, and returns a projection function
+ * that move the child controls at the source index to the destination index from a form array state.
+ */
+export function moveArrayControl<TValue>(from: number, to: number): (state: FormArrayState<TValue>) => FormArrayState<TValue>;
+
+/**
+ * This update function takes a source index, a destination index, an form array state, and moves the
+ * child controls at the source index to the destination index in the form array state.
+ */
+export function moveArrayControl<TValue>(from: number, to: number, state: FormArrayState<TValue>): FormArrayState<TValue>;
+
+export function moveArrayControl<TValue>(from: number, to: number, state?: FormArrayState<TValue>) {
+  if (!!state) {
+    return formArrayReducer(state, new MoveArrayControlAction(state.id, from, to));
+  }
+
+  return (s: FormArrayState<TValue>) => moveArrayControl(from, to, ensureState(s));
+}

--- a/src/update-function/swap-array-control.spec.ts
+++ b/src/update-function/swap-array-control.spec.ts
@@ -1,0 +1,23 @@
+import { createFormArrayState } from '../state';
+import { swapArrayControl } from './swap-array-control';
+import { FORM_CONTROL_ID } from './test-util';
+
+describe('swapArrayControl', () => {
+  const INITIAL_ARRAY_STATE = createFormArrayState(FORM_CONTROL_ID, [ 0, 1, 2, 3 ]);
+
+  it('should call reducer for arrays', () => {
+    const resultState = swapArrayControl<number>(1, 2)(INITIAL_ARRAY_STATE);
+    expect(resultState).not.toBe(INITIAL_ARRAY_STATE);
+    expect(resultState.value).toEqual([ 0, 2, 1, 3 ]);
+  });
+
+  it('should call reducer for arrays uncurried', () => {
+    const resultState = swapArrayControl<number>(3, 1, INITIAL_ARRAY_STATE);
+    expect(resultState).not.toBe(INITIAL_ARRAY_STATE);
+    expect(resultState.value).toEqual([ 0, 3, 2, 1 ]);
+  });
+
+  it('should throw if curried and no state', () => {
+    expect(() => swapArrayControl<number>(0, 1)(undefined as any)).toThrowError();
+  });
+});

--- a/src/update-function/swap-array-control.ts
+++ b/src/update-function/swap-array-control.ts
@@ -10,7 +10,7 @@ import { ensureState } from './util';
 export function swapArrayControl<TValue>(from: number, to: number): (state: FormArrayState<TValue>) => FormArrayState<TValue>;
 
 /**
- * This update function takes a source index, a destination index, a form array state, and swap the
+ * This update function takes a source index, a destination index, a form array state, and swaps the
  * child controls at the source and destination indices in the form array state.
  */
 export function swapArrayControl<TValue>(from: number, to: number, state: FormArrayState<TValue>): FormArrayState<TValue>;

--- a/src/update-function/swap-array-control.ts
+++ b/src/update-function/swap-array-control.ts
@@ -1,0 +1,24 @@
+import { SwapArrayControlAction } from '../actions';
+import { formArrayReducer } from '../array/reducer';
+import { FormArrayState } from '../state';
+import { ensureState } from './util';
+
+/**
+ * This update function takes an index and returns a projection function
+ * that swaps the child controls at the source and destination indices in a form array state.
+ */
+export function swapArrayControl<TValue>(from: number, to: number): (state: FormArrayState<TValue>) => FormArrayState<TValue>;
+
+/**
+ * This update function takes a source index, a destination index, an form array state, and swap the
+ * child controls at the source and destination indices in the form array state.
+ */
+export function swapArrayControl<TValue>(from: number, to: number, state: FormArrayState<TValue>): FormArrayState<TValue>;
+
+export function swapArrayControl<TValue>(from: number, to: number, state?: FormArrayState<TValue>) {
+  if (!!state) {
+    return formArrayReducer(state, new SwapArrayControlAction(state.id, from, to));
+  }
+
+  return (s: FormArrayState<TValue>) => swapArrayControl(from, to, ensureState(s));
+}

--- a/src/update-function/swap-array-control.ts
+++ b/src/update-function/swap-array-control.ts
@@ -10,7 +10,7 @@ import { ensureState } from './util';
 export function swapArrayControl<TValue>(from: number, to: number): (state: FormArrayState<TValue>) => FormArrayState<TValue>;
 
 /**
- * This update function takes a source index, a destination index, an form array state, and swap the
+ * This update function takes a source index, a destination index, a form array state, and swap the
  * child controls at the source and destination indices in the form array state.
  */
 export function swapArrayControl<TValue>(from: number, to: number, state: FormArrayState<TValue>): FormArrayState<TValue>;

--- a/src/update-function/swap-array-control.ts
+++ b/src/update-function/swap-array-control.ts
@@ -4,7 +4,7 @@ import { FormArrayState } from '../state';
 import { ensureState } from './util';
 
 /**
- * This update function takes an index and returns a projection function
+ * This update function takes a source index, a destination index, and returns a projection function
  * that swaps the child controls at the source and destination indices in a form array state.
  */
 export function swapArrayControl<TValue>(from: number, to: number): (state: FormArrayState<TValue>) => FormArrayState<TValue>;

--- a/src/update-function/swap-array-control.ts
+++ b/src/update-function/swap-array-control.ts
@@ -11,7 +11,7 @@ export function swapArrayControl<TValue>(from: number, to: number): (state: Form
 
 /**
  * This update function takes a source index, a destination index, a form array state, and swaps the
- * child controls at the source and destination indices in the form array state.
+ * child controls at the source and destination indices in a form array state.
  */
 export function swapArrayControl<TValue>(from: number, to: number, state: FormArrayState<TValue>): FormArrayState<TValue>;
 


### PR DESCRIPTION
This pull request adds two new actions, update functions and reducers to ngrx-forms: SwapArrayControlAction and MoveArrayControlAction.

Modeled after similar actions present in [redux-form](https://redux-form.com/7.3.0/docs/api/fieldarray.md/#-code-fields-swap-indexa-integer-indexb-integer-function-code-), they allow the user to manipulate the order of form arrays a bit more conveniently. 
These two actions are especially useful in the context of reordering form controls (for example, within a drag-and-drop scenario).

The usage is straightforward:
```typescript
const formState = createFormArrayState(FORM_CONTROL_ID, [0, 1, 2, 3]);
    
const swapped = swapArrayControl(0, 3)(formState);  // swapped = [3, 1, 2, 0]
    
const moved = moveArrayControl(0, 3)(formState);    // moved = [1, 2, 3, 0]
    
const movedBackwards = moveArrayControl(3, 0)(formState);   // movedBackwards = [3, 0, 1, 2]
```


I have included tests and documentation in the PR. 
I hope some other people will find this feature useful.