### PR TITLE
Removes "Event" type which causes problems with NativeScript

### DIFF
--- a/src/group/directive.ts
+++ b/src/group/directive.ts
@@ -21,7 +21,7 @@ export class NgrxFormDirective<TValue extends { [key: string]: any }> implements
   }
 
   @HostListener('submit', ['$event'])
-  onSubmit(event: Event) {
+  onSubmit(event: any) {
     event.preventDefault();
     if (this.state.isUnsubmitted) {
       this.actionsSubject.next(new MarkAsSubmittedAction(this.state.id));


### PR DESCRIPTION
This verifies it works without this Event type. However using any isn't ideal. Not sure if you want to accept this. I tested in a hello world NS ap and a more complex one.