### PR TITLE
keep null | undefined union of implicit return types in declaration files by using the project tsconfig.json with ng-packagr

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "es2015": "ngrx/forms.js",
   "main": "bundles/forms.umd.js",
   "scripts": {
-    "build": "ng-packagr -p package.json && rimraf ./dist/example-app ./dist/types",
+    "build": "ng-packagr -p package.json -c tsconfig.json && rimraf ./dist/example-app ./dist/types",
     "test": "karma start",
     "test-headless": "karma start --browsers ChromeHeadless",
     "test-no-progress": "karma start --reporters spec,karma-typescript",


### PR DESCRIPTION
**Problem description**
When validating an optional field we get a typescript error.

```
const validateForm = (form: FormGroupState<{ optional: string | undefined}>) => {
    return updateGroup<{ optional: string | undefined}>({
        optional: validate(maxLength(10)),
    })(form);
};
```
`Argument of type "<T extends string | any[] | Boxed<string> | Boxed<any[]>>(value: T) => ValidationErrors" is not assignable to parameter of type "ValidationFn<string | undefined>".`

The reason for this is that the return type for maxLength is incorrect in the declaration file:

_max-length.d.ts_
```
export declare function maxLength(maxLengthParam: number): <T extends string | any[] | Boxed<string> | Boxed<any[]>>(value: T) => ValidationErrors;
```

But in the source code:
_max-length.ts_
```
return <T extends string | Boxed<string> | any[] | Boxed<any[]> | null | undefined>(value: T): ValidationErrors
```

The null | undefined union is missing in the declaration file. The reason for this is that ng-packagr is by default not using a strict null checking mode. In regular mode the null | undefined union is automatically removed from implicit return types.

**Solution**
Two ways to fix this:
1) make return type to explicit (which is why the email validation _IS_ working)
2) use strict typescript in ng-packagr.

This PR is using the projects tsconfig for ng-packagr.


