### PR TITLE
fix: minLength should not validate empty values

### DIFF
--- a/validation/src/min-length.spec.ts
+++ b/validation/src/min-length.spec.ts
@@ -18,6 +18,14 @@ describe(minLength.name, () => {
     expect(minLength(2)(undefined)).toEqual({});
   });
 
+  it('should not return an error for an empty string', () => {
+    expect(minLength(2)('')).toEqual({});
+  });
+
+  it('should not return an error for an empty array', () => {
+    expect(minLength(2)([])).toEqual({});
+  });
+
   it('should not return an error if string value\'s length is greater than minLength', () => {
     expect(minLength(2)('abc')).toEqual({});
   });

--- a/validation/src/min-length.ts
+++ b/validation/src/min-length.ts
@@ -57,6 +57,10 @@ export function minLength(minLengthParam: number) {
 
     const length = (value as string | any[]).length;
 
+    if (length === 0) {
+      return {}; // don't validate empty values to allow optional controls
+    }
+
     if (length >= minLengthParam) {
       return {};
     }


### PR DESCRIPTION
`minLength` should only validate the value when there is a value, so an empty string or array should not be validated with `minLength`, which will allow optional controls to function as expected.

This also aligns with Angular's `minLength` function (https://github.com/angular/angular/blob/bbeac0727b8f267a47aba1ff1bcfc8cc5ca15b61/packages/forms/src/validators.ts#L287)