### PR TITLE
Apply lessThan/greaterThan validator only for numbers

### DIFF
--- a/docs/user-guide/validation.md
+++ b/docs/user-guide/validation.md
@@ -16,6 +16,7 @@ The following table lists all validation functions provided by **ngrx-forms**.
 |`minLength`|Requires a `string` or `array` value to have a minimum length. Empty strings and arrays are always valid to allow for optional form controls. Use this function together with `required` if those values should not be valid|
 |`maxLength`|Requires a `string` or `array` value to have a maximum length|
 |`email`|Requires a `string` value to be a valid e-mail address. Empty strings are always valid to allow for optional form controls. Use this function together with `required` if empty strings should not be valid|
+|`number`|Requires the value to be a `number`|
 |`pattern`|Requires a `string` value to match a regular expression. Empty strings are always valid to allow for optional form controls. Use this function together with `required` if empty strings should not be valid|
 
 Below you can see an example of how these functions can be used:

--- a/validation/public_api.ts
+++ b/validation/public_api.ts
@@ -16,5 +16,6 @@ export { minLength, MinLengthValidationError } from './src/min-length';
 export { notEqualTo, NotEqualToValidationError } from './src/not-equal-to';
 export { pattern, PatternValidationError } from './src/pattern';
 export { required, RequiredValidationError } from './src/required';
+export { number, NumberValidationError } from './src/number';
 export { requiredFalse } from './src/required-false';
 export { requiredTrue } from './src/required-true';

--- a/validation/src/greater-than-or-equal-to.spec.ts
+++ b/validation/src/greater-than-or-equal-to.spec.ts
@@ -18,6 +18,10 @@ describe(greaterThanOrEqualTo.name, () => {
     expect(greaterThanOrEqualTo(1)(undefined)).toEqual({});
   });
 
+  it('should not return an error for non-numeric value', () => {
+    expect(greaterThanOrEqualTo(1)('string' as any)).toEqual({});
+  });
+
   it('should not return an error if value is greater than comparand', () => {
     expect(greaterThanOrEqualTo(1)(2)).toEqual({});
   });

--- a/validation/src/greater-than-or-equal-to.ts
+++ b/validation/src/greater-than-or-equal-to.ts
@@ -14,7 +14,7 @@ declare module 'ngrx-forms/src/state' {
 
 /**
  * A validation function that requires the value to be greater than or equal to a number.
- * Considers `null` and `undefined` as valid. Combine this function with the `required`
+ * Considers `null`, `undefined` and non-numeric values as valid. Combine this function with the `required`
  * validation function if `null` or `undefined` should be considered invalid.
  *
  * The validation error returned by this validation function has the following shape:
@@ -49,7 +49,7 @@ export function greaterThanOrEqualTo(comparand: number) {
   return <T extends number | Boxed<number> | null | undefined>(value: T): ValidationErrors => {
     value = unbox(value) as number | null | undefined as T;
 
-    if (value === null || value === undefined) {
+    if (value === null || value === undefined || typeof value !== 'number') {
       return {};
     }
 

--- a/validation/src/greater-than.spec.ts
+++ b/validation/src/greater-than.spec.ts
@@ -18,6 +18,14 @@ describe(greaterThan.name, () => {
     expect(greaterThan(1)(undefined)).toEqual({});
   });
 
+  it('should not return an error for undefined', () => {
+    expect(greaterThan(1)('' as any)).toEqual({});
+  });
+
+  it('should not return an error for non-numeric value', () => {
+    expect(greaterThan(1)('string' as any)).toEqual({});
+  });
+
   it('should not return an error if value is greater than comparand', () => {
     expect(greaterThan(1)(2)).toEqual({});
   });

--- a/validation/src/greater-than.ts
+++ b/validation/src/greater-than.ts
@@ -14,7 +14,7 @@ declare module 'ngrx-forms/src/state' {
 
 /**
  * A validation function that requires the value to be greater than a number.
- * Considers `null` and `undefined` as valid. Combine this function with the `required`
+ * Considers `null`, `undefined` and non-numeric values as valid. Combine this function with the `required`
  * validation function if `null` or `undefined` should be considered invalid.
  *
  * The validation error returned by this validation function has the following shape:
@@ -49,7 +49,7 @@ export function greaterThan(comparand: number) {
   return <T extends number | Boxed<number> | null | undefined>(value: T): ValidationErrors => {
     value = unbox(value) as number | null | undefined as T;
 
-    if (value === null || value === undefined) {
+    if (value === null || value === undefined || typeof value !== 'number') {
       return {};
     }
 

--- a/validation/src/less-than-or-equal-to.spec.ts
+++ b/validation/src/less-than-or-equal-to.spec.ts
@@ -18,6 +18,10 @@ describe(lessThanOrEqualTo.name, () => {
     expect(lessThanOrEqualTo(1)(undefined)).toEqual({});
   });
 
+  it('should not return an error for non-numeric value', () => {
+    expect(lessThanOrEqualTo(1)('string' as any)).toEqual({});
+  });
+
   it('should return an error if value is greater than comparand', () => {
     expect(lessThanOrEqualTo(1)(2)).not.toEqual({});
   });
@@ -45,7 +49,7 @@ describe(lessThanOrEqualTo.name, () => {
     expect(lessThanOrEqualTo(1)(box(0))).toEqual({});
   });
 
-  it('should return errors with comparand and actual properties', () => {
+  it('should return errors with comparand and actual properties for boxed values', () => {
     const comparand = 1;
     const actual = box(2);
     expect(lessThanOrEqualTo(comparand)(actual)).toEqual({

--- a/validation/src/less-than-or-equal-to.ts
+++ b/validation/src/less-than-or-equal-to.ts
@@ -14,7 +14,7 @@ declare module 'ngrx-forms/src/state' {
 
 /**
  * A validation function that requires the value to be less than or equal to a number.
- * Considers `null` and `undefined` as valid. Combine this function with the `required`
+ * Considers `null`, `undefined` and non-numeric values as valid. Combine this function with the `required`
  * validation function if `null` or `undefined` should be considered invalid.
  *
  * The validation error returned by this validation function has the following shape:
@@ -49,7 +49,7 @@ export function lessThanOrEqualTo(comparand: number) {
   return <T extends number | Boxed<number> | null | undefined>(value: T): ValidationErrors => {
     value = unbox(value) as number | null | undefined as T;
 
-    if (value === null || value === undefined) {
+    if (value === null || value === undefined || typeof value !== 'number') {
       return {};
     }
 

--- a/validation/src/less-than.spec.ts
+++ b/validation/src/less-than.spec.ts
@@ -18,6 +18,10 @@ describe(lessThan.name, () => {
     expect(lessThan(1)(undefined)).toEqual({});
   });
 
+  it('should not return an error for non-numeric value', () => {
+    expect(lessThan(1)('string' as any)).toEqual({});
+  });
+
   it('should return an error if value is greater than comparand', () => {
     expect(lessThan(1)(2)).not.toEqual({});
   });

--- a/validation/src/less-than.ts
+++ b/validation/src/less-than.ts
@@ -14,7 +14,7 @@ declare module 'ngrx-forms/src/state' {
 
 /**
  * A validation function that requires the value to be less than a number.
- * Considers `null` and `undefined` as valid. Combine this function with the `required`
+ * Considers `null`, `undefined` and non-numeric values as valid. Combine this function with the `required`
  * validation function if `null` or `undefined` should be considered invalid.
  *
  * The validation error returned by this validation function has the following shape:
@@ -49,7 +49,7 @@ export function lessThan(comparand: number) {
   return <T extends number | Boxed<number> | null | undefined>(value: T): ValidationErrors => {
     value = unbox(value) as number | null | undefined as T;
 
-    if (value === null || value === undefined) {
+    if (value === null || value === undefined || typeof value !== 'number') {
       return {};
     }
 

--- a/validation/src/number.spec.ts
+++ b/validation/src/number.spec.ts
@@ -1,0 +1,62 @@
+import { AbstractControlState, box, unbox, validate } from 'ngrx-forms';
+import { number } from './number';
+
+describe(number.name, () => {
+  it('should not return an error for null', () => {
+    expect(number(null)).toEqual({});
+  });
+
+  it('should not return an error for undefined', () => {
+    expect(number(undefined)).toEqual({});
+  });
+
+  it('should not return an error for any number', () => {
+    expect(number(-123.45)).toEqual({});
+    expect(number(-123)).toEqual({});
+    expect(number(0)).toEqual({});
+    expect(number(123)).toEqual({});
+    expect(number(123.45)).toEqual({});
+  });
+
+  it('should not return an error for any boxed number', () => {
+    expect(number(box(123))).toEqual({});
+  });
+
+  it('should return an error if value is not a number', () => {
+    expect(number('abc' as any)).not.toEqual({});
+    expect(number(false as any)).not.toEqual({});
+    expect(number([] as any)).not.toEqual({});
+  });
+
+  it('should return an unboxed error if value is not a number', () => {
+    expect(number(box('abc' as any))).not.toEqual({});
+  });
+
+  it('should return error with actual property', () => {
+    const actual = 'abc' as any;
+    expect(number(actual)).toEqual({
+      number: {
+        actual,
+      },
+    });
+  });
+
+  it('should return error with actual property for boxed value', () => {
+    const actual = box('abc' as any);
+    expect(number(actual)).toEqual({
+      number: {
+        actual: unbox(actual),
+      },
+    });
+  });
+
+  it('should properly infer value type when used with validate update function', () => {
+    // this code is never meant to be executed, it should just pass the type checker
+    if (1 !== 1) {
+      const state: AbstractControlState<number> = undefined!;
+      const v = validate(state, number);
+      const v2: number = v.value;
+      console.log(v2);
+    }
+  });
+});

--- a/validation/src/number.ts
+++ b/validation/src/number.ts
@@ -1,0 +1,53 @@
+import { Boxed, unbox, ValidationErrors } from 'ngrx-forms';
+
+export interface NumberValidationError<T> {
+  actual: T;
+}
+
+// @ts-ignore
+declare module 'ngrx-forms/src/state' {
+  export interface ValidationErrors {
+    number?: NumberValidationError<any>;
+  }
+}
+
+/**
+ * A validation function that requires a value to be a valid number.
+ * Considers `null` and `undefined` as valid. Combine this function with the
+ * `required` validation function if these values should be considered invalid.
+ *
+ * The validation error returned by this validation function has the following shape:
+ *
+```typescript
+{
+  number: {
+    actual: any;
+  };
+}
+```
+ *
+ * Usually you would use this validation function in conjunction with the `validate`
+ * update function to perform synchronous validation in your reducer:
+ *
+```typescript
+updateGroup<MyFormValue>({
+  amount: validate(number),
+})
+```
+ *
+ * Note that this function is generic to allow the compiler to properly infer the type
+ * of the `validate` function for both optional and non-optional controls.
+ */
+export function number<T extends number | Boxed<number> | null | undefined>(value: T): ValidationErrors {
+  value = unbox(value) as number | null | undefined as T;
+
+  if (value === null || value === undefined || typeof value === 'number') {
+    return {};
+  }
+
+  return {
+    number: {
+      actual: value,
+    },
+  };
+}


### PR DESCRIPTION
Currently `lessThan`, `lessThanOrEqualTo`, `greaterThan`, `greaterThanOrEqualTo` validators are suitable for cases when you're sure about the possible values - to always have a number here.

But it's quite common to have a text field without input restrictions and rather rely on validators - in such case these validators does not give much - they still try to compare any non-empty value you provide. So incorrect values like "not number" are still validated which does not make much sense.

My proposal, similarly to `required` validator, only take into account true numbers - otherwise pass (as it does for null/undefined values). With a combination of `number` validator - you can achieve pretty much the standard behavior for text-free inputs.