### PR TITLE
feat: add NGRX_UPDATE_ON_TYPE type to library exports

### DIFF
--- a/src/ngrx-forms.ts
+++ b/src/ngrx-forms.ts
@@ -71,7 +71,7 @@ export { NgrxRangeViewAdapter } from './view-adapter/range';
 export { NgrxSelectViewAdapter, NgrxSelectOption } from './view-adapter/select';
 export { NgrxSelectMultipleViewAdapter, NgrxSelectMultipleOption } from './view-adapter/select-multiple';
 
-export { NgrxFormControlDirective } from './control/directive';
+export { NgrxFormControlDirective, NGRX_UPDATE_ON_TYPE } from './control/directive';
 export { NgrxLocalFormControlDirective } from './control/local-state-directive';
 export { NgrxFormDirective } from './group/directive';
 export { NgrxLocalFormDirective } from './group/local-state-directive';


### PR DESCRIPTION
I faced with a case where I need to programmatically set the `ngrxUpdateOn` value from a directive. Therefore It would be great to have an access to `NGRX_UPDATE_ON_TYPE` so I wouldn't need to have a crappy code like `.ngrxUpdateOn = 'blur' as any`.
I hope this might be relevant for others too.