### PR TITLE
Update: added a function for nested store slices + documentation

### DIFF
--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -78,7 +78,7 @@ export function appReducer(state = initialState, action: Action): AppState {
 }
 ```
 
-If you are using ngrx version 8 or above you can alternatively use `onNgrxForms` with `createReducer`:
+If you are using ngrx version 8 or above you can alternatively use `onNgrxForms` with `createReducer` for top level store slices:
 
 ```ts
 import { createReducer } from '@ngrx/store';
@@ -88,6 +88,26 @@ export const appReducer = createReducer(
   initialState,
   onNgrxForms(),
   // your other reducers...
+);
+```
+
+If you would like to nest forms below the top level of the store use `onNgrxForm` with `createReducer` instead on your specific reducer:
+
+```ts
+import { createReducer } from '@ngrx/store';
+import { onNgrxForm } from 'ngrx-forms';
+
+export interface AppState {
+  featureX: FeatureX;
+  featureY: {
+    someOtherNestedSlice: SomeOtherNestedSlice,
+    myForm: FormGroupState<MyFormValue>;
+  }
+}
+
+export const myFormReducer = createReducer(
+  initialFeatureState,
+  onNgrxForm(),
 );
 ```
 

--- a/docs/user-guide/updating-the-state.md
+++ b/docs/user-guide/updating-the-state.md
@@ -49,7 +49,7 @@ export function reducer(state = initialState, action: Action) {
 }
 ```
 
-If you are using ngrx version 8 or above you can alternatively use `onNgrxForms`, `onNgrxFormsAction`, and `wrapReducerWithFormStateUpdate` with `createReducer`:
+If you are using ngrx version 8 or above you can alternatively use `onNgrxForms`, `onNgrxForm`, `onNgrxFormsAction`, and `wrapReducerWithFormStateUpdate` with `createReducer`:
 
 ```ts
 import { createReducer } from '@ngrx/store';
@@ -84,6 +84,21 @@ export const reducer = wrapReducerWithFormStateUpdate(
   s => s.loginForm,
   // this function is always called after the reducer
   validateLoginForm,
+);
+```
+
+Use in an Individual/Nested Reducer
+
+```ts
+import { createReducer } from '@ngrx/store';
+import { onNgrxForm } from 'ngrx-forms';
+
+const nestedReducer = createReducer(
+  initialNestedState,
+
+  // manually call the appropriate reducer for the state slice
+  onNgrxForm(),
+  // your other action reducers...
 );
 ```
 

--- a/src/ngrx-forms.ts
+++ b/src/ngrx-forms.ts
@@ -29,6 +29,7 @@ export {
   createFormStateReducerWithUpdate,
   formStateReducer,
   onNgrxForms,
+  onNgrxForm,
   onNgrxFormsAction,
   wrapReducerWithFormStateUpdate,
 } from './reducer';

--- a/src/reducer.spec.ts
+++ b/src/reducer.spec.ts
@@ -1,6 +1,6 @@
 import { Action, createReducer } from '@ngrx/store';
 import { MarkAsDirtyAction, MarkAsTouchedAction, SetValueAction } from './actions';
-import { createFormStateReducerWithUpdate, formStateReducer, onNgrxForms, onNgrxFormsAction, wrapReducerWithFormStateUpdate } from './reducer';
+import { createFormStateReducerWithUpdate, formStateReducer, onNgrxForm, onNgrxForms, onNgrxFormsAction, wrapReducerWithFormStateUpdate } from './reducer';
 import { FORM_CONTROL_ID, FORM_CONTROL_INNER5_ID, FORM_CONTROL_INNER_ID, FormGroupValue, INITIAL_STATE } from './update-function/test-util';
 import { updateGroup } from './update-function/update-group';
 
@@ -169,6 +169,61 @@ describe(onNgrxForms.name, () => {
     const reducer = createReducer(
       state,
       onNgrxForms(),
+    );
+
+    let resultState = reducer(state, new MarkAsTouchedAction(FORM_CONTROL_INNER_ID));
+    expect(resultState.control).not.toBe(INITIAL_STATE.controls.inner);
+
+    resultState = reducer(state, new MarkAsTouchedAction(FORM_CONTROL_ID));
+    expect(resultState.group).not.toBe(INITIAL_STATE);
+
+    resultState = reducer(state, new MarkAsTouchedAction(FORM_CONTROL_INNER5_ID));
+    expect(resultState.array).not.toBe(INITIAL_STATE.controls.inner5);
+  });
+});
+
+describe(onNgrxForm.name, () => {
+  it('should call the reducer for controls', () => {
+    const state = {
+      prop: 'value',
+      form: INITIAL_STATE.controls.inner,
+    };
+
+    const resultState = onNgrxForm().reducer(state, new MarkAsTouchedAction(FORM_CONTROL_INNER_ID));
+    expect(resultState.form).not.toBe(INITIAL_STATE.controls.inner);
+  });
+
+  it('should call the reducer for groups', () => {
+    const state = {
+      prop: 'value',
+      form: INITIAL_STATE,
+    };
+
+    const resultState = onNgrxForm().reducer(state, new MarkAsTouchedAction(FORM_CONTROL_ID));
+    expect(resultState.form).not.toBe(INITIAL_STATE);
+  });
+
+  it('should call the reducer for arrays', () => {
+    const state = {
+      prop: 'value',
+      form: INITIAL_STATE.controls.inner5,
+    };
+
+    const resultState = onNgrxForm().reducer(state, new MarkAsTouchedAction(FORM_CONTROL_INNER5_ID));
+    expect(resultState.form).not.toBe(INITIAL_STATE.controls.inner5);
+  });
+
+  it('should work with createReducer', () => {
+    const state = {
+      prop: 'value',
+      control: INITIAL_STATE.controls.inner,
+      group: INITIAL_STATE,
+      array: INITIAL_STATE.controls.inner5,
+    };
+
+    const reducer = createReducer(
+      state,
+      onNgrxForm(),
     );
 
     let resultState = reducer(state, new MarkAsTouchedAction(FORM_CONTROL_INNER_ID));

--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -112,9 +112,9 @@ export function onNgrxForms<TState = any>(): { reducer: ActionReducer<TState>; t
  * This function is an individualized version of onNgrxForms for use cases
  * where either no root reducer exists or the state is nested below the top level of the store
  */
-export function onNgrxForm<TState = any>(): { reducer: ActionReducer<TState>; types: string[] } {
+export function onNgrxForm(): { reducer: ActionReducer<any>; types: string[] } {
   return {
-    reducer: (state, action) => (isFormState(state) && { ...formStateReducer(state, action) }),
+    reducer: (state, action) => isFormState(state) && { ...formStateReducer(state, action) },
     types: ALL_NGRX_FORMS_ACTION_TYPES,
   };
 }

--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -108,6 +108,18 @@ export function onNgrxForms<TState = any>(): { reducer: ActionReducer<TState>; t
   };
 }
 
+
+/**
+ * This function is an individualized version of onNgrxForms for use cases
+ * where either no root reducer exists or the state is nested below the first level of the store
+ */
+export function onNgrxForm<TState = any>(): { reducer: ActionReducer<TState>; types: string[] } {
+  return {
+    reducer: (state, action) => (isFormState(state) && { ...formStateReducer(state, action) }),
+    types: ALL_NGRX_FORMS_ACTION_TYPES,
+  };
+}
+
 export interface ActionConstructor {
   new(...args: any[]): Actions<any>;
   readonly TYPE: string;

--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -108,10 +108,9 @@ export function onNgrxForms<TState = any>(): { reducer: ActionReducer<TState>; t
   };
 }
 
-
 /**
  * This function is an individualized version of onNgrxForms for use cases
- * where either no root reducer exists or the state is nested below the first level of the store
+ * where either no root reducer exists or the state is nested below the top level of the store
  */
 export function onNgrxForm<TState = any>(): { reducer: ActionReducer<TState>; types: string[] } {
   return {


### PR DESCRIPTION
onNgrxForms is only usable in a root reducer so i added onNgrxForm to handle individual use cases where we don't necessarily want to traverse every key or where a slice of state is nested below the top level of the store.