### PR TITLE
Add validation for sequential characters

### DIFF
--- a/docs/user-guide/validation.md
+++ b/docs/user-guide/validation.md
@@ -18,6 +18,7 @@ The following table lists all validation functions provided by **ngrx-forms**.
 |`email`|Requires a `string` value to be a valid e-mail address. Empty strings are always valid to allow for optional form controls. Use this function together with `required` if empty strings should not be valid|
 |`number`|Requires the value to be a `number`|
 |`pattern`|Requires a `string` value to match a regular expression. Empty strings are always valid to allow for optional form controls. Use this function together with `required` if empty strings should not be valid|
+|`noSequentialCharacters`|Requires a `string` to not have sequential characters (e.g. 'abc' or '234') beyond provided length.|
 
 Below you can see an example of how these functions can be used:
 

--- a/validation/src/no-sequential-character.spec.ts
+++ b/validation/src/no-sequential-character.spec.ts
@@ -1,0 +1,65 @@
+import { AbstractControlState, box, validate } from 'ngrx-forms';
+import { noSequentialCharacters } from './no-sequential-characters';
+
+describe(noSequentialCharacters.name, () => {
+  it('should not return an error if value does not contain sequential characters in requisite length', () => {
+    expect(noSequentialCharacters(3)('password')).toEqual({});
+    expect(noSequentialCharacters(4)('abc')).toEqual({});
+    expect(noSequentialCharacters(5)('Thank you for MrWolfZ')).toEqual({});
+  });
+
+  it('should not return an error if a boxed value does not contain sequential characters in requisite length', () => {
+    expect(noSequentialCharacters(3)(box('password'))).toEqual({});
+    expect(noSequentialCharacters(4)(box('abc'))).toEqual({});
+    expect(noSequentialCharacters(5)(box('Thank you for MrWolfZ'))).toEqual({});
+  });
+
+  it('should not return an error if value is null', () => {
+    expect(noSequentialCharacters(3)(null)).toEqual({});
+  });
+
+  it('should not return an error if value is undefined', () => {
+    expect(noSequentialCharacters(3)(undefined)).toEqual({});
+  });
+
+  it('should not return an error if sequence contains "z" in position not last', () => {
+    expect(noSequentialCharacters(3)('yz{')).toEqual({});
+  });
+
+  it('should not return an error if sequence contains "Z" in position not last', () => {
+    expect(noSequentialCharacters(3)('YZ[')).toEqual({});
+  });
+
+  it('should not return an error if sequence contains "0" in position not last', () => {
+    expect(noSequentialCharacters(3)('89:')).toEqual({});
+  });
+
+  it('should throw for null maxLength parameter', () => {
+    expect(() => noSequentialCharacters(null as any)).toThrow();
+  });
+
+  it('should return an error with value and detected sequence if one is found', () => {
+    expect(noSequentialCharacters(4)('1234password')).toEqual({
+      noSequentialCharacters: {
+        value: '1234password',
+        detectedSequence: '1234',
+      }
+    });
+    expect(noSequentialCharacters(3)('superstar')).toEqual({
+      noSequentialCharacters: {
+        value: 'superstar',
+        detectedSequence: 'rst',
+      }
+    });
+  });
+
+  it('should properly infer value type when used with validate update function', () => {
+    // this code is never meant to be executed, it should just pass the type checker
+    if (1 !== 1) {
+      const state: AbstractControlState<string> = undefined!;
+      const v = validate(state, noSequentialCharacters(3));
+      const v2: string = v.value;
+      console.log(v2);
+    }
+  });
+});

--- a/validation/src/no-sequential-characters.ts
+++ b/validation/src/no-sequential-characters.ts
@@ -1,0 +1,100 @@
+import { Boxed, unbox, ValidationErrors } from 'ngrx-forms';
+
+export interface SequentialCharacterValidationError {
+  value: string;
+  detectedSequence: string;
+}
+
+// @ts-ignore
+declare module 'ngrx-forms/src/state' {
+  export interface ValidationErrors {
+    noSequentialCharacters?: SequentialCharacterValidationError;
+  }
+}
+
+/**
+ * A validation function that invalidates input if `maxLength` number of sequential
+ * characters (e.g. 'abc' or '123') are detected.
+ *
+ * The validation error returned by this validation function has the following shape:
+ *
+```typescript
+{
+  noSequentialCharacters: {
+    value: string;
+    detectedSequence: string;
+  };
+}
+```
+ *
+ * Usually you would use this validation function in conjunction with the `validate`
+ * update function to perform synchronous validation in your reducer:
+ *
+```typescript
+updateGroup<MyFormValue>({
+  name: validate(noSequentialCharacters(3)),
+})
+```
+ */
+export function noSequentialCharacters(maxLengthParam: number) {
+  // tslint:disable-next-line:strict-type-predicates (guard for users without strict type checking)
+  if (maxLengthParam === null || maxLengthParam === undefined) {
+    throw new Error(`The maxLength Validation function requires the maxLength parameter to be a non-null number, got ${maxLengthParam}!`);
+  }
+
+  return <T extends string | Boxed<string> | any[] | Boxed<any[]> | null | undefined>(value: T): ValidationErrors => {
+    if (value === null || value === undefined) {
+      return {};
+    }
+
+    value = unbox(value);
+    let foundSequence = detectedSequence(value, maxLengthParam);
+
+    return foundSequence ? {
+      noSequentialCharacters: {
+        value: value as string,
+        detectedSequence: foundSequence as string,
+      }
+    } : {};
+  };
+}
+
+function detectedSequence(value: any, maxLength: number) {
+  if (value.length < maxLength) {
+    return false;
+  }
+
+  let detectedSequence;
+  let sequentialChars = 1;
+  let lastCharCode = value.charCodeAt(0);
+
+  for(let i = 1; i < value.length; i++) {
+    let currentCharCode = value.charCodeAt(i);
+    // special cases - 'z', 'Z' and '9' - set counter to 0 & move on to next iteration of the loop
+    if ([122, 90, 57].indexOf(currentCharCode) !== -1) {
+      sequentialChars = 1;
+      continue;
+    }
+
+    // compare to previous character, increment or reset counter
+    if (currentCharCode === lastCharCode + 1) {
+      sequentialChars++;
+    } else {
+      sequentialChars = 1;
+    }
+
+    // break out of a loop as soon as maxLength of sequential characters detected
+    if (sequentialChars === maxLength) {
+      detectedSequence = value.substr(i + 1 - maxLength, maxLength);
+      break;
+    }
+
+    lastCharCode = currentCharCode;
+  }
+
+  if (sequentialChars >= maxLength) {
+    return detectedSequence;
+  } else {
+    return false;
+  }
+}

--- a/validation/src/no-sequential-characters.ts
+++ b/validation/src/no-sequential-characters.ts
@@ -64,7 +64,7 @@ function detectedSequence(value: any, maxLength: number) {
     return false;
   }
 
-  let detectedSequence;
+  let foundSequence;
   let sequentialChars = 1;
   let lastCharCode = value.charCodeAt(0);
 
@@ -85,7 +85,7 @@ function detectedSequence(value: any, maxLength: number) {
 
     // break out of a loop as soon as maxLength of sequential characters detected
     if (sequentialChars === maxLength) {
-      detectedSequence = value.substr(i + 1 - maxLength, maxLength);
+      foundSequence = value.substr(i + 1 - maxLength, maxLength);
       break;
     }
 
@@ -93,7 +93,7 @@ function detectedSequence(value: any, maxLength: number) {
   }
 
   if (sequentialChars >= maxLength) {
-    return detectedSequence;
+    return foundSequence;
   } else {
     return false;
   }


### PR DESCRIPTION
Hi @MrWolfZ!

First, thanks for all the work on this library!

For our project, we needed to invalidate passwords that had sequential characters like 'abc' or '456'. I'm new to Typescript, but copying one of your existing validations and adding logic (perhaps naive but functional) to achieve this result seems to have worked. With that said though, there are copied chunks that I don't fully understand, so quite possibly some is extraneous - feedback would be most welcome and would be a great learning opportunity 😃 

This is my first attempt at contributing to an open source project (apart from some readme typo fixes here and there).